### PR TITLE
Changed defineTasks to return an array...

### DIFF
--- a/schemas/define-tasks-response.json
+++ b/schemas/define-tasks-response.json
@@ -11,19 +11,29 @@
       "format":         "date-time"
     },
     "tasks": {
-      "description":    "Mapping from `taskId` to object with `taskPutUrl` property.",
-      "type":           "object",
-      "additionalProperties": {
-        "description":  "Task description object",
+      "description":    "List of `taskId`, `taskPutUrl` and `taskUrl`",
+      "type":           "array",
+      "items": {
+        "description":  "Task definition object",
         "type":         "object",
         "properties": {
+          "taskId": {
+            "description":  "Unique task identifier, used when the defined task is to be scheduled.",
+            "type":         "string",
+            "pattern":      {"$const": "slugid-pattern"}
+          },
+          "taskUrl": {
+            "description":  "URL for the task, when uploaded using `taskPutUrl` below.",
+            "type":         "string",
+            "format":       "uri"
+          },
           "taskPutUrl": {
             "description":  "Signed PUT URL to which the task definition can be uploaded. **Note**, `Content-Length` must be given and `Content-Type` must be set to `application/json`.",
             "type":         "string",
             "format":       "uri"
           }
         },
-        "required": ["taskPutUrl"]
+        "required": ["taskId", "taskUrl", "taskPutUrl"]
       }
     }
   },

--- a/test/api/define_schedule_task.js
+++ b/test/api/define_schedule_task.js
@@ -1,4 +1,4 @@
-suite('Test reruns', function() {
+suite('Test define/schedule', function() {
   var debug       = require('debug')('define_schedule_test');
   var assert      = require('assert');
   var Promise     = require('promise');
@@ -60,7 +60,7 @@ suite('Test reruns', function() {
     return got_tasks.then(function(res) {
       assert(res.ok, "This should have succeeded");
       assert(
-        Object.keys(res.body.tasks).length == 5,
+        res.body.tasks.length == 5,
         "Didn't generate number of tasks requested"
       );
     });
@@ -81,8 +81,8 @@ suite('Test reruns', function() {
         Object.keys(res.body.tasks).length == 1,
         "Didn't generate number of tasks requested"
       );
-      taskId = Object.keys(res.body.tasks)[0];
-      return res.body.tasks[taskId].taskPutUrl;
+      taskId = res.body.tasks[0].taskId;
+      return res.body.tasks[0].taskPutUrl;
     });
 
     // Create datetime for created and deadline as 3 days later


### PR DESCRIPTION
Instead of the format:

``` js
tasks: {
   <taskId>: {
    taskPutUrl: "....."
  },
}
```

We'll now have:

``` js
tasks: [
  {
    taskId: "<taskId>",
    taskUrL: '.....',
    taskPutUrl: "....."
  },
]
```

This is eaiser to extend... and easier to consume... the other format is a little backwards... There is really no point in mapping from `taskId` to something... As opposed to do a list. It makes a little sense for artifacts url requests, so we might keep it there...

But I think it should go for this case..

**Note**, I'm currently updating the task-graph scheduler, so I suggest that we hold this back until it's ready for the new format... Which is very close.
