### PR TITLE
Added 'extra' field for extra data

### DIFF
--- a/schemas/create-task-request.yml
+++ b/schemas/create-task-request.yml
@@ -150,12 +150,28 @@ properties:
     title:            "Tags"
     description: |
       Arbitrary key-value tags (only strings limited to 4k). These can be used
-      to attached informal meta-data to a task. For example fields to be
-      displayed on treeherder or tbpl.
+      to attach informal meta-data to a task. Use this for informal tags that
+      tasks can be classified by. You can also think of strings here as
+      candidates for formal meta-data. Something like
+      `purpose: 'build' || 'test'` is a good example.
     type:             object
     additionalProperties:
       type:           string
       maxLength:      4096
+    default:          {}
+  extra:
+    title:            "Extra Data"
+    description: |
+      Object with properties that can hold any kind of extra data that should be
+      associated with the task. This can be data for the task which doesn't
+      fit into `payload`, or it can supplementary data for use in services
+      listening for events from this task. For example this could be details to
+      display on _treeherder_, or information for indexing the task. Please, try
+      to put all related information under one property, so `extra` data keys
+      for treeherder reporting and task indexing don't conflict, hence, we have
+      reusable services. **Warning**, do not stuff large data-sets in here,
+      task definitions should not take-up multiple MiBs.
+    type:             object
     default:          {}
 additionalProperties: false
 required:

--- a/schemas/task.yml
+++ b/schemas/task.yml
@@ -145,12 +145,28 @@ properties:
     title:            "Tags"
     description: |
       Arbitrary key-value tags (only strings limited to 4k). These can be used
-      to attached informal meta-data to a task. For example fields to be
-      displayed on treeherder or tbpl.
+      to attach informal meta-data to a task. Use this for informal tags that
+      tasks can be classified by. You can also think of strings here as
+      candidates for formal meta-data. Something like
+      `purpose: 'build' || 'test'` is a good example.
     type:             object
     additionalProperties:
       type:           string
       maxLength:      4096
+  extra:
+    title:            "Extra Data"
+    description: |
+      Object with properties that can hold any kind of extra data that should be
+      associated with the task. This can be data for the task which doesn't
+      fit into `payload`, or it can supplementary data for use in services
+      listening for events from this task. For example this could be details to
+      display on _treeherder_, or information for indexing the task. Please, try
+      to put all related information under one property, so `extra` data keys
+      for treeherder reporting and task indexing don't conflict, hence, we have
+      reusable services. **Warning**, do not stuff large data-sets in here,
+      task definitions should not take-up multiple MiBs.
+    type:             object
+    default:          {}
 additionalProperties: false
 required:
   - provisionerId
@@ -166,3 +182,4 @@ required:
   - payload
   - metadata
   - tags
+  - extra

--- a/test/api/createtask_test.js
+++ b/test/api/createtask_test.js
@@ -38,6 +38,11 @@ suite('Create task', function() {
     },
     tags: {
       purpose:        'taskcluster-testing'
+    },
+    extra: {
+      myUsefulDetails: {
+        property:     "that is useful by external service!!"
+      }
     }
   };
 

--- a/test/api/gettask_test.js
+++ b/test/api/gettask_test.js
@@ -32,7 +32,8 @@ suite('Get task', function() {
     },
     tags: {
       purpose:        'taskcluster-testing'
-    }
+    },
+    extra: {}
   };
 
   test("getTask", function() {

--- a/test/validate_test/task.json
+++ b/test/validate_test/task.json
@@ -18,5 +18,6 @@
   },
   "tags": {
     "purpose":        "taskcluster-testing"
-  }
+  },
+  "extra": {}
 }


### PR DESCRIPTION
Added an optional field `extra` that we store extra data in...

I also improved the documentation of `tags`, hopefully it's a little bit more obvious what it does.
Test works locally, there is nothing breaking except tasks already submitted can't be loaded anymore (well, maybe it works).

But new tasks will work regardless of whether or not they specify the `extra` property.
**Note,** the difference between task definition in `create-task-request.yml` and `task.yml`, the latter is used when returning tasks.

If anybody has a better name I'm open for suggestions, but I would like to deploy this soon. Shouldn't take any time.
