### PR TITLE
Include the workertype in list of pending tasks

### DIFF
--- a/queue/task.js
+++ b/queue/task.js
@@ -443,7 +443,10 @@ Task.queryPending = transacting(function(provisionerId, knex) {
       'runs.state':           'pending'
     }).then(function(tasks) {
       return tasks.map(function(task) {
-        return slugid.encode(task.taskId);
+        return {
+          taskId: slugid.encode(task.taskId),
+          workerType: task.workerType
+        }
       });
     });
 });


### PR DESCRIPTION
For the provisioner, we need to know not the number of pending tasks but rather
the number of pending tasks for each worker type.  As the api is implemented
now, we need to fetch the list of all pending tasks for the provisioner in
question, then do a /task/:taskId for each taskId which is pending to determine
which workerType a given task needs.

  Let's instead includ this information in the return value from the get
  pending tasks endpoint.  The cost is JSON overhead and string data with a
  benefit of reducing the number of API calls substantially.