### PR TITLE
Minor tweaks!

### DIFF
--- a/routes/api/artifacts.js
+++ b/routes/api/artifacts.js
@@ -20,8 +20,8 @@ api.declare({
     ]
   ],
   deferAuth:  true,
-  input:      SCHEMA_PREFIX_CONST + 'post-artifact-request.json',
-  output:     SCHEMA_PREFIX_CONST + 'post-artifact-response.json',
+  input:      SCHEMA_PREFIX_CONST + 'post-artifact-request.json#',
+  output:     SCHEMA_PREFIX_CONST + 'post-artifact-response.json#',
   title:      "Create Artifact",
   description: [
     "This API end-point creates an artifact for a specific run of a task. This",
@@ -478,7 +478,7 @@ api.declare({
   method:     'get',
   route:      '/task/:taskId/runs/:runId/artifacts',
   name:       'listArtifacts',
-  output:     SCHEMA_PREFIX_CONST + 'list-artifacts-response.json',
+  output:     SCHEMA_PREFIX_CONST + 'list-artifacts-response.json#',
   title:      "Get Artifacts from Run",
   description: [
     "Returns a list of artifacts and associated meta-data for a given run."
@@ -506,7 +506,7 @@ api.declare({
   method:     'get',
   route:      '/task/:taskId/artifacts',
   name:       'listLatestArtifacts',
-  output:     SCHEMA_PREFIX_CONST + 'list-artifacts-response.json',
+  output:     SCHEMA_PREFIX_CONST + 'list-artifacts-response.json#',
   title:      "Get Artifacts from Latest Run",
   description: [
     "Returns a list of artifacts and associated meta-data for the latest run",

--- a/schemas/list-artifacts-response.yml
+++ b/schemas/list-artifacts-response.yml
@@ -1,5 +1,5 @@
 id:       http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#
-$schema:  http://json-schema.org/draft-04/schema#"
+$schema:  http://json-schema.org/draft-04/schema#
 title:          "List Artifacts Response"
 description: |
   List of artifacts for a given `taskId` and `runId`.
@@ -14,6 +14,7 @@ properties:
       title:      "Artifact"
       description: |
         Information about an artifact for the given `taskId` and `runId`.
+      type:       object
       properties:
         storageType:
           title:    "Artifact Storage-Type"


### PR DESCRIPTION
Hey Jonas,
I believe these commits fix some very minor issues.

1) For consistency I wanted to add the "object" type to list-artifacts-response.yml where it was not explicitly stated, as this was the only place where it wasn't (I only noticed when I hit a problem parsing).

2) The other tweak is adding the # character to the end of some of the Input and Output url json schema references. I haven't tested the code change, but I am hoping that will fix e.g. lines 267-268 in http://references.taskcluster.net/queue/v1/api.json:
```
267       "input": "http://schemas.taskcluster.net/queue/v1/post-artifact-request.json",
268       "output": "http://schemas.taskcluster.net/queue/v1/post-artifact-response.json"
```
to be consistent with the other references, e.g.:
```
 22       "input": "http://schemas.taskcluster.net/queue/v1/create-task-request.json#",
 23       "output": "http://schemas.taskcluster.net/queue/v1/task-status-response.json#"

 55       "input": "http://schemas.taskcluster.net/queue/v1/create-task-request.json#",
 56       "output": "http://schemas.taskcluster.net/queue/v1/task-status-response.json#"

125       "input": "http://schemas.taskcluster.net/queue/v1/task-claim-request.json#",
126       "output": "http://schemas.taskcluster.net/queue/v1/task-claim-response.json#"
```
etc...

Some of the other repos also have the missing # in places but I'll only raise PRs for those once I know if you are happy in principle with the change!
Thanks,
Pete