### PR TITLE
Backport pollflow

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ mv /tmp/pg_hba.conf /etc/postgresql/9.1/main/pg_hba.conf;
 sudo service postgresql restart;
 
 # Dependencies that we are likely to change over time
-sudo apt-get update;
-sudo apt-get -y install screen vim;
+#sudo apt-get update;
+#sudo apt-get -y install screen vim;
 SCRIPT
 end

--- a/bin/server.js
+++ b/bin/server.js
@@ -111,8 +111,7 @@ var launch = function(profile) {
   // Create QueueService to manage azure queues
   var queueService = new QueueService({
     prefix:           cfg.get('queue:queuePrefix'),
-    credentials:      cfg.get('azure'),
-    signatureSecret:  cfg.get('queue:signatureSecret')
+    credentials:      cfg.get('azure')
   });
 
   // When: publisher, validator and containers are created, proceed

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,8 +9,7 @@
       "dependencies": {
         "aws-sdk-apis": {
           "version": "3.1.10",
-          "from": "aws-sdk-apis@>=3.1.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/aws-sdk-apis/-/aws-sdk-apis-3.1.10.tgz"
+          "from": "aws-sdk-apis@>=3.1.0 <4.0.0"
         },
         "xml2js": {
           "version": "0.2.6",
@@ -38,13 +37,11 @@
       "dependencies": {
         "promise": {
           "version": "4.0.0",
-          "from": "promise@>=4.0.0 <4.1.0",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-4.0.0.tgz",
+          "from": "promise@~4.0.0",
           "dependencies": {
             "asap": {
               "version": "1.0.0",
-              "from": "asap@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
+              "from": "asap@~1.0.0"
             }
           }
         }
@@ -52,8 +49,7 @@
     },
     "azure-storage": {
       "version": "0.4.2",
-      "from": "azure-storage@0.4.2",
-      "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-0.4.2.tgz",
+      "from": "azure-storage@^0.4.2",
       "dependencies": {
         "xml2js": {
           "version": "0.2.7",
@@ -74,114 +70,98 @@
         },
         "underscore": {
           "version": "1.4.4",
-          "from": "underscore@>=1.4.4 <1.5.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+          "from": "underscore@~1.4.4"
         },
         "request": {
           "version": "2.27.0",
-          "from": "request@>=2.27.0 <2.28.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.27.0.tgz",
+          "from": "request@~2.27.0",
           "dependencies": {
             "qs": {
               "version": "0.6.6",
-              "from": "qs@>=0.6.0 <0.7.0",
+              "from": "qs@~0.6.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
             },
             "json-stringify-safe": {
               "version": "5.0.0",
-              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+              "from": "json-stringify-safe@~5.0.0"
             },
             "forever-agent": {
               "version": "0.5.2",
-              "from": "forever-agent@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+              "from": "forever-agent@~0.5.0"
             },
             "tunnel-agent": {
               "version": "0.3.0",
-              "from": "tunnel-agent@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
+              "from": "tunnel-agent@~0.3.0"
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "http-signature@>=0.10.0 <0.11.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "from": "http-signature@~0.10.0",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "assert-plus@>=0.1.5 <0.2.0"
+                  "from": "assert-plus@^0.1.5"
                 },
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "asn1@0.1.11",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                  "from": "asn1@0.1.11"
                 },
                 "ctype": {
                   "version": "0.5.3",
-                  "from": "ctype@0.5.3",
-                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                  "from": "ctype@0.5.3"
                 }
               }
             },
             "hawk": {
               "version": "1.0.0",
-              "from": "hawk@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+              "from": "hawk@~1.0.0",
               "dependencies": {
                 "hoek": {
                   "version": "0.9.1",
-                  "from": "hoek@>=0.9.0 <0.10.0",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                  "from": "hoek@0.9.x"
                 },
                 "boom": {
                   "version": "0.4.2",
-                  "from": "boom@>=0.4.0 <0.5.0"
+                  "from": "boom@0.4.x"
                 },
                 "cryptiles": {
                   "version": "0.2.2",
-                  "from": "cryptiles@>=0.2.0 <0.3.0"
+                  "from": "cryptiles@0.2.x"
                 },
                 "sntp": {
                   "version": "0.2.4",
-                  "from": "sntp@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                  "from": "sntp@0.2.x"
                 }
               }
             },
             "aws-sign": {
               "version": "0.3.0",
-              "from": "aws-sign@>=0.3.0 <0.4.0"
+              "from": "aws-sign@~0.3.0"
             },
             "oauth-sign": {
               "version": "0.3.0",
-              "from": "oauth-sign@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+              "from": "oauth-sign@~0.3.0"
             },
             "cookie-jar": {
               "version": "0.3.0",
-              "from": "cookie-jar@>=0.3.0 <0.4.0"
+              "from": "cookie-jar@~0.3.0"
             },
             "form-data": {
               "version": "0.1.4",
-              "from": "form-data@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+              "from": "form-data@~0.1.0",
               "dependencies": {
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@>=0.0.4 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "from": "combined-stream@~0.0.4",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                      "from": "delayed-stream@0.0.5"
                     }
                   }
                 },
                 "async": {
                   "version": "0.9.0",
-                  "from": "async@>=0.9.0 <0.10.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                  "from": "async@~0.9.0"
                 }
               }
             }
@@ -189,47 +169,39 @@
         },
         "validator": {
           "version": "3.1.0",
-          "from": "validator@>=3.1.0 <3.2.0",
-          "resolved": "https://registry.npmjs.org/validator/-/validator-3.1.0.tgz"
+          "from": "validator@~3.1.0"
         },
         "mime": {
           "version": "1.2.11",
-          "from": "mime@>=1.2.4 <1.3.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+          "from": "mime@~1.2.9"
         },
         "node-uuid": {
           "version": "1.4.2",
-          "from": "node-uuid@>=1.4.0 <1.5.0",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+          "from": "node-uuid@~1.4.1"
         },
         "extend": {
           "version": "1.2.1",
-          "from": "extend@>=1.2.1 <1.3.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz"
+          "from": "extend@~1.2.1"
         },
         "readable-stream": {
           "version": "1.0.33",
-          "from": "readable-stream@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+          "from": "readable-stream@~1.0.0",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "core-util-is@>=1.0.0 <1.1.0"
+              "from": "core-util-is@~1.0.0"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+              "from": "isarray@0.0.1"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "string_decoder@>=0.10.0 <0.11.0",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+              "from": "string_decoder@~0.10.x"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "from": "inherits@~2.0.1"
             }
           }
         }
@@ -242,13 +214,11 @@
       "dependencies": {
         "boom": {
           "version": "2.6.1",
-          "from": "boom@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz",
+          "from": "boom@2.x.x",
           "dependencies": {
             "hoek": {
               "version": "2.11.0",
-              "from": "hoek@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
+              "from": "hoek@2.x.x"
             }
           }
         }
@@ -261,8 +231,7 @@
       "dependencies": {
         "ms": {
           "version": "0.6.2",
-          "from": "ms@0.6.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+          "from": "ms@0.6.2"
         }
       }
     },
@@ -272,105 +241,87 @@
       "resolved": "https://registry.npmjs.org/knex/-/knex-0.7.3.tgz",
       "dependencies": {
         "bluebird": {
-          "version": "2.9.3",
-          "from": "bluebird@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.3.tgz"
+          "version": "2.9.12",
+          "from": "bluebird@^2.0.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.12.tgz"
         },
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "from": "chalk@~0.5.1",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+              "from": "ansi-styles@^1.1.0"
             },
             "escape-string-regexp": {
               "version": "1.0.2",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+              "from": "escape-string-regexp@^1.0.0"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "from": "has-ansi@^0.1.0",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                  "from": "ansi-regex@^0.2.0"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "from": "strip-ansi@^0.3.0",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                  "from": "ansi-regex@^0.2.1"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+              "from": "supports-color@^0.2.0"
             }
           }
         },
         "commander": {
           "version": "2.6.0",
-          "from": "commander@>=2.2.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
+          "from": "commander@^2.2.0"
         },
         "generic-pool-redux": {
           "version": "0.1.0",
-          "from": "generic-pool-redux@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/generic-pool-redux/-/generic-pool-redux-0.1.0.tgz"
+          "from": "generic-pool-redux@~0.1.0"
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "inherits@>=2.0.1 <2.1.0",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+          "from": "inherits@~2.0.1"
         },
         "interpret": {
           "version": "0.3.10",
-          "from": "interpret@>=0.3.2 <0.4.0",
-          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.3.10.tgz"
+          "from": "interpret@^0.3.2"
         },
         "liftoff": {
           "version": "0.13.6",
-          "from": "liftoff@>=0.13.2 <0.14.0",
-          "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-0.13.6.tgz",
+          "from": "liftoff@~0.13.2",
           "dependencies": {
             "findup-sync": {
               "version": "0.1.3",
-              "from": "findup-sync@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+              "from": "findup-sync@~0.1.2",
               "dependencies": {
                 "glob": {
                   "version": "3.2.11",
-                  "from": "glob@>=3.2.9 <3.3.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "from": "glob@~3.2.9",
                   "dependencies": {
                     "minimatch": {
                       "version": "0.3.0",
-                      "from": "minimatch@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "from": "minimatch@0.3",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                          "from": "lru-cache@2"
                         },
                         "sigmund": {
                           "version": "1.0.0",
-                          "from": "sigmund@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                          "from": "sigmund@~1.0.0"
                         }
                       }
                     }
@@ -380,68 +331,57 @@
             },
             "resolve": {
               "version": "1.0.0",
-              "from": "resolve@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.0.0.tgz"
+              "from": "resolve@~1.0.0"
             },
             "extend": {
               "version": "1.3.0",
-              "from": "extend@>=1.3.0 <1.4.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz"
+              "from": "extend@~1.3.0"
             },
             "flagged-respawn": {
               "version": "0.3.1",
-              "from": "flagged-respawn@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz"
+              "from": "flagged-respawn@~0.3.0"
             }
           }
         },
         "minimist": {
           "version": "1.1.0",
-          "from": "minimist@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz"
+          "from": "minimist@~1.1.0"
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "from": "mkdirp@^0.5.0",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+              "from": "minimist@0.0.8"
             }
           }
         },
         "readable-stream": {
           "version": "1.1.13",
-          "from": "readable-stream@>=1.1.12 <2.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "from": "readable-stream@1.1",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "core-util-is@>=1.0.0 <1.1.0"
+              "from": "core-util-is@~1.0.0"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+              "from": "isarray@0.0.1"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "string_decoder@>=0.10.0 <0.11.0",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+              "from": "string_decoder@~0.10.x"
             }
           }
         },
         "tildify": {
           "version": "1.0.0",
-          "from": "tildify@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.0.0.tgz",
+          "from": "tildify@~1.0.0",
           "dependencies": {
             "user-home": {
               "version": "1.1.1",
-              "from": "user-home@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+              "from": "user-home@^1.0.0"
             }
           }
         }
@@ -473,14 +413,13 @@
           "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-0.0.3.tgz",
           "dependencies": {
             "split": {
-              "version": "0.3.2",
-              "from": "split@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/split/-/split-0.3.2.tgz",
+              "version": "0.3.3",
+              "from": "split@~0.3",
+              "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
               "dependencies": {
                 "through": {
                   "version": "2.3.6",
-                  "from": "through@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                  "from": "through@2"
                 }
               }
             }
@@ -510,8 +449,7 @@
       "dependencies": {
         "asap": {
           "version": "1.0.0",
-          "from": "asap@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
+          "from": "asap@~1.0.0"
         }
       }
     },
@@ -539,18 +477,15 @@
           "dependencies": {
             "accepts": {
               "version": "1.1.4",
-              "from": "accepts@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
+              "from": "accepts@~1.1.0",
               "dependencies": {
                 "mime-types": {
-                  "version": "2.0.7",
-                  "from": "mime-types@>=2.0.7 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.7.tgz",
+                  "version": "2.0.9",
+                  "from": "mime-types@~2.0.9",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.5.0",
-                      "from": "mime-db@>=1.5.0 <1.6.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.5.0.tgz"
+                      "version": "1.7.0",
+                      "from": "mime-db@~1.7.0"
                     }
                   }
                 },
@@ -583,8 +518,7 @@
             },
             "etag": {
               "version": "1.3.1",
-              "from": "etag@>=1.3.0 <1.4.0",
-              "resolved": "https://registry.npmjs.org/etag/-/etag-1.3.1.tgz",
+              "from": "etag@~1.3.0",
               "dependencies": {
                 "crc": {
                   "version": "3.0.0",
@@ -615,8 +549,7 @@
             },
             "on-finished": {
               "version": "2.1.1",
-              "from": "on-finished@>=2.1.0 <2.2.0",
-              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.1.tgz",
+              "from": "on-finished@~2.1.0",
               "dependencies": {
                 "ee-first": {
                   "version": "1.1.0",
@@ -627,8 +560,7 @@
             },
             "parseurl": {
               "version": "1.3.0",
-              "from": "parseurl@>=1.3.0 <1.4.0",
-              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+              "from": "parseurl@~1.3.0"
             },
             "path-to-regexp": {
               "version": "0.1.3",
@@ -654,8 +586,7 @@
             },
             "range-parser": {
               "version": "1.0.2",
-              "from": "range-parser@>=1.0.2 <1.1.0",
-              "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
+              "from": "range-parser@~1.0.2"
             },
             "send": {
               "version": "0.9.1",
@@ -669,13 +600,11 @@
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "mime@1.2.11",
-                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                  "from": "mime@1.2.11"
                 },
                 "ms": {
                   "version": "0.6.2",
-                  "from": "ms@0.6.2",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                  "from": "ms@0.6.2"
                 },
                 "on-finished": {
                   "version": "2.1.0",
@@ -692,9 +621,9 @@
               }
             },
             "serve-static": {
-              "version": "1.6.4",
-              "from": "serve-static@>=1.6.1 <1.7.0",
-              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.4.tgz",
+              "version": "1.6.5",
+              "from": "serve-static@~1.6.1",
+              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.5.tgz",
               "dependencies": {
                 "send": {
                   "version": "0.9.3",
@@ -713,8 +642,7 @@
                     },
                     "etag": {
                       "version": "1.4.0",
-                      "from": "etag@>=1.4.0 <1.5.0",
-                      "resolved": "https://registry.npmjs.org/etag/-/etag-1.4.0.tgz",
+                      "from": "etag@~1.4.0",
                       "dependencies": {
                         "crc": {
                           "version": "3.0.0",
@@ -725,13 +653,11 @@
                     },
                     "mime": {
                       "version": "1.2.11",
-                      "from": "mime@1.2.11",
-                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                      "from": "mime@1.2.11"
                     },
                     "ms": {
                       "version": "0.6.2",
-                      "from": "ms@0.6.2",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                      "from": "ms@0.6.2"
                     },
                     "on-finished": {
                       "version": "2.1.0",
@@ -750,19 +676,17 @@
               }
             },
             "type-is": {
-              "version": "1.5.5",
-              "from": "type-is@>=1.5.1 <1.6.0",
-              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.5.tgz",
+              "version": "1.5.7",
+              "from": "type-is@~1.5.1",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
               "dependencies": {
                 "mime-types": {
-                  "version": "2.0.7",
-                  "from": "mime-types@>=2.0.7 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.7.tgz",
+                  "version": "2.0.9",
+                  "from": "mime-types@~2.0.9",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.5.0",
-                      "from": "mime-db@>=1.5.0 <1.6.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.5.0.tgz"
+                      "version": "1.7.0",
+                      "from": "mime-db@~1.7.0"
                     }
                   }
                 }
@@ -770,8 +694,7 @@
             },
             "vary": {
               "version": "1.0.0",
-              "from": "vary@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
+              "from": "vary@~1.0.0"
             },
             "cookie": {
               "version": "0.1.2",
@@ -802,8 +725,7 @@
           "dependencies": {
             "pkginfo": {
               "version": "0.2.3",
-              "from": "pkginfo@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz"
+              "from": "pkginfo@0.2.x"
             }
           }
         },
@@ -824,13 +746,11 @@
             },
             "mkdirp": {
               "version": "0.5.0",
-              "from": "mkdirp@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "from": "mkdirp@~0.5.0",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                  "from": "minimist@0.0.8"
                 }
               }
             },
@@ -841,20 +761,17 @@
               "dependencies": {
                 "promise": {
                   "version": "2.0.0",
-                  "from": "promise@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
+                  "from": "promise@~2.0",
                   "dependencies": {
                     "is-promise": {
                       "version": "1.0.1",
-                      "from": "is-promise@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz"
+                      "from": "is-promise@~1"
                     }
                   }
                 },
                 "css": {
                   "version": "1.0.8",
-                  "from": "css@>=1.0.8 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
+                  "from": "css@~1.0.8",
                   "dependencies": {
                     "css-parse": {
                       "version": "1.0.4",
@@ -870,13 +787,11 @@
                 },
                 "uglify-js": {
                   "version": "2.2.5",
-                  "from": "uglify-js@>=2.2.5 <2.3.0",
-                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+                  "from": "uglify-js@~2.2.5",
                   "dependencies": {
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "source-map@>=0.1.7 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "from": "source-map@~0.1.7",
                       "dependencies": {
                         "amdefine": {
                           "version": "0.1.0",
@@ -886,13 +801,11 @@
                     },
                     "optimist": {
                       "version": "0.3.7",
-                      "from": "optimist@>=0.3.5 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                      "from": "optimist@~0.3.5",
                       "dependencies": {
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "wordwrap@>=0.0.2 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                          "from": "wordwrap@~0.0.2"
                         }
                       }
                     }
@@ -912,23 +825,19 @@
               "dependencies": {
                 "readdirp": {
                   "version": "0.2.5",
-                  "from": "readdirp@>=0.2.3 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-0.2.5.tgz",
+                  "from": "readdirp@~0.2.3",
                   "dependencies": {
                     "minimatch": {
                       "version": "2.0.1",
                       "from": "minimatch@>=0.2.4",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.0",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "from": "brace-expansion@^1.0.0",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.2.0",
-                              "from": "balanced-match@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                              "from": "balanced-match@^0.2.0"
                             },
                             "concat-map": {
                               "version": "0.0.1",
@@ -945,17 +854,15 @@
             },
             "with": {
               "version": "3.0.1",
-              "from": "with@>=3.0.0 <3.1.0",
-              "resolved": "https://registry.npmjs.org/with/-/with-3.0.1.tgz",
+              "from": "with@~3.0.0",
               "dependencies": {
                 "uglify-js": {
                   "version": "2.4.16",
-                  "from": "uglify-js@>=2.4.0 <2.5.0",
-                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
+                  "from": "uglify-js@~2.4.12",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@>=0.2.6 <0.3.0"
+                      "from": "async@~0.2.6"
                     },
                     "source-map": {
                       "version": "0.1.34",
@@ -970,20 +877,17 @@
                     },
                     "optimist": {
                       "version": "0.3.7",
-                      "from": "optimist@>=0.3.5 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                      "from": "optimist@~0.3.5",
                       "dependencies": {
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "wordwrap@>=0.0.2 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                          "from": "wordwrap@~0.0.2"
                         }
                       }
                     },
                     "uglify-to-browserify": {
                       "version": "1.0.2",
-                      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                      "from": "uglify-to-browserify@~1.0.0"
                     }
                   }
                 }
@@ -991,17 +895,15 @@
             },
             "constantinople": {
               "version": "2.0.1",
-              "from": "constantinople@>=2.0.0 <2.1.0",
-              "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-2.0.1.tgz",
+              "from": "constantinople@~2.0.0",
               "dependencies": {
                 "uglify-js": {
                   "version": "2.4.16",
-                  "from": "uglify-js@>=2.4.0 <2.5.0",
-                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
+                  "from": "uglify-js@~2.4.0",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@>=0.2.6 <0.3.0"
+                      "from": "async@~0.2.6"
                     },
                     "source-map": {
                       "version": "0.1.34",
@@ -1016,20 +918,17 @@
                     },
                     "optimist": {
                       "version": "0.3.7",
-                      "from": "optimist@>=0.3.5 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                      "from": "optimist@~0.3.5",
                       "dependencies": {
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "wordwrap@>=0.0.2 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                          "from": "wordwrap@~0.0.2"
                         }
                       }
                     },
                     "uglify-to-browserify": {
                       "version": "1.0.2",
-                      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                      "from": "uglify-to-browserify@~1.0.0"
                     }
                   }
                 }
@@ -1044,43 +943,35 @@
           "dependencies": {
             "css-parse": {
               "version": "1.7.0",
-              "from": "css-parse@>=1.7.0 <1.8.0",
-              "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz"
+              "from": "css-parse@1.7.x"
             },
             "mkdirp": {
               "version": "0.3.5",
-              "from": "mkdirp@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+              "from": "mkdirp@0.3.x"
             },
             "sax": {
               "version": "0.5.8",
-              "from": "sax@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz"
+              "from": "sax@0.5.x"
             },
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.0 <3.3.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@3.2.x",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "from": "inherits@2"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@0.3",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                      "from": "lru-cache@2"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                      "from": "sigmund@~1.0.0"
                     }
                   }
                 }
@@ -1088,8 +979,7 @@
             },
             "source-map": {
               "version": "0.1.43",
-              "from": "source-map@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "from": "source-map@0.1.x",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
@@ -1110,9 +1000,9 @@
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
             },
             "ini": {
-              "version": "1.3.2",
-              "from": "ini@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.2.tgz"
+              "version": "1.3.3",
+              "from": "ini@1.x.x",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
             },
             "optimist": {
               "version": "0.6.0",
@@ -1121,13 +1011,11 @@
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                  "from": "wordwrap@~0.0.2"
                 },
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@>=0.0.1 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                  "from": "minimist@~0.0.1"
                 }
               }
             }
@@ -1140,20 +1028,17 @@
           "dependencies": {
             "asap": {
               "version": "1.0.0",
-              "from": "asap@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
+              "from": "asap@~1.0.0"
             }
           }
         },
         "debug": {
           "version": "2.0.0",
           "from": "debug@2.0.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "ms@0.6.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+              "from": "ms@0.6.2"
             }
           }
         },
@@ -1164,103 +1049,86 @@
           "dependencies": {
             "qs": {
               "version": "0.6.6",
-              "from": "qs@0.6.6",
+              "from": "qs@~0.6.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
             },
             "formidable": {
               "version": "1.0.14",
-              "from": "formidable@1.0.14",
-              "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz"
+              "from": "formidable@1.0.14"
             },
             "mime": {
               "version": "1.2.11",
-              "from": "mime@1.2.11",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+              "from": "mime@~1.2.9"
             },
             "component-emitter": {
               "version": "1.1.2",
-              "from": "component-emitter@1.1.2",
-              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+              "from": "component-emitter@1.1.2"
             },
             "methods": {
               "version": "1.0.1",
-              "from": "methods@1.0.1",
-              "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz"
+              "from": "methods@1.0.1"
             },
             "cookiejar": {
               "version": "2.0.1",
-              "from": "cookiejar@2.0.1",
-              "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.1.tgz"
+              "from": "cookiejar@2.0.1"
             },
             "debug": {
               "version": "1.0.4",
-              "from": "debug@>=1.0.1 <1.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
+              "from": "debug@~1.0.1",
               "dependencies": {
                 "ms": {
                   "version": "0.6.2",
-                  "from": "ms@0.6.2",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                  "from": "ms@0.6.2"
                 }
               }
             },
             "reduce-component": {
               "version": "1.0.1",
-              "from": "reduce-component@1.0.1",
-              "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz"
+              "from": "reduce-component@1.0.1"
             },
             "extend": {
               "version": "1.2.1",
-              "from": "extend@>=1.2.1 <1.3.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz"
+              "from": "extend@~1.2.1"
             },
             "form-data": {
               "version": "0.1.3",
               "from": "form-data@0.1.3",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.3.tgz",
               "dependencies": {
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@>=0.0.4 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "from": "combined-stream@~0.0.4",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                      "from": "delayed-stream@0.0.5"
                     }
                   }
                 },
                 "async": {
                   "version": "0.9.0",
-                  "from": "async@>=0.9.0 <0.10.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                  "from": "async@~0.9.0"
                 }
               }
             },
             "readable-stream": {
               "version": "1.0.27-1",
               "from": "readable-stream@1.0.27-1",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0"
+                  "from": "core-util-is@~1.0.0"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "from": "isarray@0.0.1"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                  "from": "string_decoder@~0.10.x"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "from": "inherits@~2.0.1"
                 }
               }
             }
@@ -1274,30 +1142,26 @@
         "superagent-hawk": {
           "version": "0.0.4",
           "from": "superagent-hawk@0.0.4",
-          "resolved": "https://registry.npmjs.org/superagent-hawk/-/superagent-hawk-0.0.4.tgz",
           "dependencies": {
             "hawk": {
               "version": "1.0.0",
-              "from": "hawk@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+              "from": "hawk@~1.0.0",
               "dependencies": {
                 "hoek": {
                   "version": "0.9.1",
-                  "from": "hoek@>=0.9.0 <0.10.0",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                  "from": "hoek@0.9.x"
                 },
                 "boom": {
                   "version": "0.4.2",
-                  "from": "boom@>=0.4.0 <0.5.0"
+                  "from": "boom@0.4.x"
                 },
                 "cryptiles": {
                   "version": "0.2.2",
-                  "from": "cryptiles@>=0.2.0 <0.3.0"
+                  "from": "cryptiles@0.2.x"
                 },
                 "sntp": {
                   "version": "0.2.4",
-                  "from": "sntp@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                  "from": "sntp@0.2.x"
                 }
               }
             }
@@ -1315,136 +1179,116 @@
           "dependencies": {
             "request": {
               "version": "2.34.0",
-              "from": "request@>=2.34.0 <2.35.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.34.0.tgz",
+              "from": "request@~2.34.0",
               "dependencies": {
                 "qs": {
                   "version": "0.6.6",
-                  "from": "qs@>=0.6.0 <0.7.0",
+                  "from": "qs@~0.6.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
                 },
                 "json-stringify-safe": {
                   "version": "5.0.0",
-                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                  "from": "json-stringify-safe@~5.0.0"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "forever-agent@>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                  "from": "forever-agent@~0.5.0"
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "mime@>=1.2.9 <1.3.0",
-                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                  "from": "mime@~1.2.9"
                 },
                 "tough-cookie": {
                   "version": "0.12.1",
                   "from": "tough-cookie@>=0.12.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
                   "dependencies": {
                     "punycode": {
                       "version": "1.3.2",
-                      "from": "punycode@>=0.2.0",
-                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                      "from": "punycode@>=0.2.0"
                     }
                   }
                 },
                 "form-data": {
                   "version": "0.1.4",
-                  "from": "form-data@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                  "from": "form-data@~0.1.0",
                   "dependencies": {
                     "combined-stream": {
                       "version": "0.0.7",
-                      "from": "combined-stream@>=0.0.4 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                      "from": "combined-stream@~0.0.4",
                       "dependencies": {
                         "delayed-stream": {
                           "version": "0.0.5",
-                          "from": "delayed-stream@0.0.5",
-                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                          "from": "delayed-stream@0.0.5"
                         }
                       }
                     },
                     "async": {
                       "version": "0.9.0",
-                      "from": "async@>=0.9.0 <0.10.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                      "from": "async@~0.9.0"
                     }
                   }
                 },
                 "tunnel-agent": {
                   "version": "0.3.0",
-                  "from": "tunnel-agent@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
+                  "from": "tunnel-agent@~0.3.0"
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "http-signature@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "from": "http-signature@~0.10.0",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "assert-plus@>=0.1.5 <0.2.0"
+                      "from": "assert-plus@^0.1.5"
                     },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "asn1@0.1.11",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                      "from": "asn1@0.1.11"
                     },
                     "ctype": {
                       "version": "0.5.3",
-                      "from": "ctype@0.5.3",
-                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                      "from": "ctype@0.5.3"
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.3.0",
-                  "from": "oauth-sign@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+                  "from": "oauth-sign@~0.3.0"
                 },
                 "hawk": {
                   "version": "1.0.0",
-                  "from": "hawk@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+                  "from": "hawk@~1.0.0",
                   "dependencies": {
                     "hoek": {
                       "version": "0.9.1",
-                      "from": "hoek@>=0.9.0 <0.10.0",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                      "from": "hoek@0.9.x"
                     },
                     "boom": {
                       "version": "0.4.2",
-                      "from": "boom@>=0.4.0 <0.5.0"
+                      "from": "boom@0.4.x"
                     },
                     "cryptiles": {
                       "version": "0.2.2",
-                      "from": "cryptiles@>=0.2.0 <0.3.0"
+                      "from": "cryptiles@0.2.x"
                     },
                     "sntp": {
                       "version": "0.2.4",
-                      "from": "sntp@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                      "from": "sntp@0.2.x"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "aws-sign2@>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                  "from": "aws-sign2@~0.5.0"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.2",
-              "from": "node-uuid@>=1.4.1 <1.5.0",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+              "from": "node-uuid@~1.4.1"
             },
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.10 <0.3.0"
+              "from": "async@~0.2.10"
             }
           }
         },
@@ -1455,8 +1299,7 @@
           "dependencies": {
             "aws-sdk-apis": {
               "version": "3.1.10",
-              "from": "aws-sdk-apis@>=3.1.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/aws-sdk-apis/-/aws-sdk-apis-3.1.10.tgz"
+              "from": "aws-sdk-apis@>=3.1.0 <4.0.0"
             },
             "xml2js": {
               "version": "0.2.6",
@@ -1485,17 +1328,14 @@
         "hawk": {
           "version": "2.3.0",
           "from": "hawk@2.3.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.0.tgz",
           "dependencies": {
             "boom": {
               "version": "2.6.1",
-              "from": "boom@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
+              "from": "boom@2.x.x"
             },
             "sntp": {
               "version": "1.0.9",
-              "from": "sntp@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+              "from": "sntp@1.x.x"
             }
           }
         },
@@ -1557,19 +1397,17 @@
               "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.0.tgz"
             },
             "type-is": {
-              "version": "1.5.5",
-              "from": "type-is@>=1.5.1 <1.6.0",
-              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.5.tgz",
+              "version": "1.5.7",
+              "from": "type-is@~1.5.1",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
               "dependencies": {
                 "mime-types": {
-                  "version": "2.0.7",
-                  "from": "mime-types@>=2.0.4 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.7.tgz",
+                  "version": "2.0.9",
+                  "from": "mime-types@~2.0.9",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.5.0",
-                      "from": "mime-db@>=1.5.0 <1.6.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.5.0.tgz"
+                      "version": "1.7.0",
+                      "from": "mime-db@~1.7.0"
                     }
                   }
                 }
@@ -1623,13 +1461,11 @@
             },
             "parseurl": {
               "version": "1.3.0",
-              "from": "parseurl@>=1.3.0 <1.4.0",
-              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+              "from": "parseurl@~1.3.0"
             },
             "vary": {
               "version": "1.0.0",
-              "from": "vary@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
+              "from": "vary@~1.0.0"
             }
           }
         },
@@ -1657,13 +1493,11 @@
           "dependencies": {
             "cookies": {
               "version": "0.4.1",
-              "from": "cookies@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.4.1.tgz",
+              "from": "cookies@~0.4.0",
               "dependencies": {
                 "keygrip": {
                   "version": "1.0.1",
-                  "from": "keygrip@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.1.tgz"
+                  "from": "keygrip@~1.0.0"
                 }
               }
             }
@@ -1676,18 +1510,15 @@
           "dependencies": {
             "accepts": {
               "version": "1.1.4",
-              "from": "accepts@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
+              "from": "accepts@~1.1.0",
               "dependencies": {
                 "mime-types": {
-                  "version": "2.0.7",
-                  "from": "mime-types@>=2.0.4 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.7.tgz",
+                  "version": "2.0.9",
+                  "from": "mime-types@~2.0.4",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.5.0",
-                      "from": "mime-db@>=1.5.0 <1.6.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.5.0.tgz"
+                      "version": "1.7.0",
+                      "from": "mime-db@~1.7.0"
                     }
                   }
                 },
@@ -1708,48 +1539,40 @@
         "amqplib": {
           "version": "0.2.1",
           "from": "amqplib@0.2.1",
-          "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.2.1.tgz",
           "dependencies": {
             "bitsyntax": {
               "version": "0.0.4",
-              "from": "bitsyntax@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/bitsyntax/-/bitsyntax-0.0.4.tgz"
+              "from": "bitsyntax@~0.0.4"
             },
             "buffer-more-ints": {
               "version": "0.0.2",
-              "from": "buffer-more-ints@0.0.2",
-              "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-0.0.2.tgz"
+              "from": "buffer-more-ints@0.0.2"
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@>=1.0.0 <2.0.0 >=1.1.9",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "from": "readable-stream@1.x >=1.1.9",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0"
+                  "from": "core-util-is@~1.0.0"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "from": "isarray@0.0.1"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                  "from": "string_decoder@~0.10.x"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "from": "inherits@~2.0.1"
                 }
               }
             },
             "when": {
               "version": "3.2.3",
-              "from": "when@>=3.2.3 <3.3.0",
-              "resolved": "https://registry.npmjs.org/when/-/when-3.2.3.tgz"
+              "from": "when@~3.2.3"
             }
           }
         },
@@ -1765,25 +1588,21 @@
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@>=0.1.11 <0.2.0",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "from": "argparse@~ 0.1.11",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "underscore@>=1.7.0 <1.8.0",
-                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+                  "from": "underscore@~1.7.0"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "underscore.string@>=2.4.0 <2.5.0",
-                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+                  "from": "underscore.string@~2.4.0"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@>=1.0.2 <1.1.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+              "from": "esprima@~ 1.0.2"
             }
           }
         },
@@ -1794,20 +1613,17 @@
           "dependencies": {
             "bindings": {
               "version": "1.2.1",
-              "from": "bindings@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
+              "from": "bindings@1.x.x"
             },
             "nan": {
               "version": "1.3.0",
-              "from": "nan@>=1.3.0 <1.4.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-1.3.0.tgz"
+              "from": "nan@1.3.x"
             }
           }
         },
         "hoek": {
           "version": "2.11.0",
-          "from": "hoek@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
+          "from": "hoek@2.x.x"
         },
         "taskcluster-client": {
           "version": "0.17.10",
@@ -1817,12 +1633,10 @@
             "debug": {
               "version": "2.1.0",
               "from": "debug@2.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.6.2",
-                  "from": "ms@0.6.2",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                  "from": "ms@0.6.2"
                 }
               }
             },
@@ -1833,103 +1647,85 @@
               "dependencies": {
                 "qs": {
                   "version": "1.2.0",
-                  "from": "qs@1.2.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.0.tgz"
+                  "from": "qs@1.2.0"
                 },
                 "formidable": {
                   "version": "1.0.14",
-                  "from": "formidable@1.0.14",
-                  "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz"
+                  "from": "formidable@1.0.14"
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "mime@1.2.11",
-                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                  "from": "mime@1.2.11"
                 },
                 "component-emitter": {
                   "version": "1.1.2",
-                  "from": "component-emitter@1.1.2",
-                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                  "from": "component-emitter@1.1.2"
                 },
                 "methods": {
                   "version": "1.0.1",
-                  "from": "methods@1.0.1",
-                  "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz"
+                  "from": "methods@1.0.1"
                 },
                 "cookiejar": {
                   "version": "2.0.1",
-                  "from": "cookiejar@2.0.1",
-                  "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.1.tgz"
+                  "from": "cookiejar@2.0.1"
                 },
                 "debug": {
                   "version": "2.0.0",
-                  "from": "debug@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+                  "from": "debug@~2.0.0",
                   "dependencies": {
                     "ms": {
                       "version": "0.6.2",
-                      "from": "ms@0.6.2",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                      "from": "ms@0.6.2"
                     }
                   }
                 },
                 "reduce-component": {
                   "version": "1.0.1",
-                  "from": "reduce-component@1.0.1",
-                  "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz"
+                  "from": "reduce-component@1.0.1"
                 },
                 "extend": {
                   "version": "1.2.1",
-                  "from": "extend@>=1.2.1 <1.3.0",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz"
+                  "from": "extend@~1.2.1"
                 },
                 "form-data": {
                   "version": "0.1.3",
                   "from": "form-data@0.1.3",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.3.tgz",
                   "dependencies": {
                     "combined-stream": {
                       "version": "0.0.7",
-                      "from": "combined-stream@>=0.0.4 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                      "from": "combined-stream@~0.0.4",
                       "dependencies": {
                         "delayed-stream": {
                           "version": "0.0.5",
-                          "from": "delayed-stream@0.0.5",
-                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                          "from": "delayed-stream@0.0.5"
                         }
                       }
                     },
                     "async": {
                       "version": "0.9.0",
-                      "from": "async@>=0.9.0 <0.10.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                      "from": "async@~0.9.0"
                     }
                   }
                 },
                 "readable-stream": {
                   "version": "1.0.27-1",
                   "from": "readable-stream@1.0.27-1",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0"
+                      "from": "core-util-is@~1.0.0"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "from": "isarray@0.0.1"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                      "from": "string_decoder@~0.10.x"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "from": "inherits@~2.0.1"
                     }
                   }
                 }
@@ -1937,8 +1733,7 @@
             },
             "superagent-promise": {
               "version": "0.2.0",
-              "from": "superagent-promise@0.2.0",
-              "resolved": "https://registry.npmjs.org/superagent-promise/-/superagent-promise-0.2.0.tgz"
+              "from": "superagent-promise@0.2.0"
             },
             "slugid": {
               "version": "1.0.3",
@@ -1948,295 +1743,236 @@
             "promise": {
               "version": "6.0.1",
               "from": "promise@6.0.1",
-              "resolved": "https://registry.npmjs.org/promise/-/promise-6.0.1.tgz",
               "dependencies": {
                 "asap": {
                   "version": "1.0.0",
-                  "from": "asap@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
+                  "from": "asap@~1.0.0"
                 }
               }
             },
             "sockjs-client-node": {
               "version": "0.1.1",
               "from": "sockjs-client-node@0.1.1",
-              "resolved": "https://registry.npmjs.org/sockjs-client-node/-/sockjs-client-node-0.1.1.tgz",
               "dependencies": {
                 "jsdom": {
                   "version": "0.10.6",
-                  "from": "jsdom@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-0.10.6.tgz",
+                  "from": "jsdom@0.10.x",
                   "dependencies": {
                     "htmlparser2": {
                       "version": "3.8.2",
-                      "from": "htmlparser2@>=3.1.5 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
+                      "from": "htmlparser2@>= 3.1.5 <4",
                       "dependencies": {
                         "domhandler": {
                           "version": "2.3.0",
-                          "from": "domhandler@>=2.3.0 <2.4.0",
-                          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
+                          "from": "domhandler@2.3"
                         },
                         "domutils": {
-                          "version": "1.5.0",
-                          "from": "domutils@>=1.5.0 <1.6.0",
-                          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz"
+                          "version": "1.5.1",
+                          "from": "domutils@1.5",
+                          "dependencies": {
+                            "dom-serializer": {
+                              "version": "0.1.0",
+                              "from": "dom-serializer@0",
+                              "dependencies": {
+                                "entities": {
+                                  "version": "1.1.1",
+                                  "from": "entities@~1.1.1"
+                                }
+                              }
+                            }
+                          }
                         },
                         "domelementtype": {
                           "version": "1.1.3",
-                          "from": "domelementtype@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                          "from": "domelementtype@1"
                         },
                         "readable-stream": {
                           "version": "1.1.13",
-                          "from": "readable-stream@>=1.1.0 <1.2.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "from": "readable-stream@1.1",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.1",
-                              "from": "core-util-is@>=1.0.0 <1.1.0"
+                              "from": "core-util-is@~1.0.0"
                             },
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "isarray@0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                              "from": "isarray@0.0.1"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                              "from": "string_decoder@~0.10.x"
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <2.1.0",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                              "from": "inherits@~2.0.1"
                             }
                           }
                         },
                         "entities": {
                           "version": "1.0.0",
-                          "from": "entities@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+                          "from": "entities@1.0"
                         }
                       }
                     },
                     "nwmatcher": {
                       "version": "1.3.4",
-                      "from": "nwmatcher@>=1.3.2 <1.4.0",
-                      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.4.tgz"
+                      "from": "nwmatcher@~1.3.2"
                     },
                     "request": {
-                      "version": "2.51.0",
-                      "from": "request@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+                      "version": "2.53.0",
+                      "from": "request@2.x",
                       "dependencies": {
                         "bl": {
                           "version": "0.9.4",
-                          "from": "bl@>=0.9.0 <0.10.0",
-                          "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                          "from": "bl@~0.9.0",
                           "dependencies": {
                             "readable-stream": {
                               "version": "1.0.33",
-                              "from": "readable-stream@>=1.0.26 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                              "from": "readable-stream@~1.0.26",
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.1",
-                                  "from": "core-util-is@>=1.0.0 <1.1.0"
+                                  "from": "core-util-is@~1.0.0"
                                 },
                                 "isarray": {
                                   "version": "0.0.1",
-                                  "from": "isarray@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                  "from": "isarray@0.0.1"
                                 },
                                 "string_decoder": {
                                   "version": "0.10.31",
-                                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                  "from": "string_decoder@~0.10.x"
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@>=2.0.1 <2.1.0",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                  "from": "inherits@~2.0.1"
                                 }
                               }
                             }
                           }
                         },
                         "caseless": {
-                          "version": "0.8.0",
-                          "from": "caseless@>=0.8.0 <0.9.0",
-                          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+                          "version": "0.9.0",
+                          "from": "caseless@~0.9.0"
                         },
                         "forever-agent": {
                           "version": "0.5.2",
-                          "from": "forever-agent@>=0.5.0 <0.6.0",
-                          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                          "from": "forever-agent@~0.5.0"
                         },
                         "form-data": {
                           "version": "0.2.0",
-                          "from": "form-data@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                          "from": "form-data@~0.2.0",
                           "dependencies": {
                             "async": {
                               "version": "0.9.0",
-                              "from": "async@>=0.9.0 <0.10.0",
-                              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-                            },
-                            "mime-types": {
-                              "version": "2.0.7",
-                              "from": "mime-types@>=2.0.3 <2.1.0",
-                              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.7.tgz",
-                              "dependencies": {
-                                "mime-db": {
-                                  "version": "1.5.0",
-                                  "from": "mime-db@>=1.5.0 <1.6.0",
-                                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.5.0.tgz"
-                                }
-                              }
+                              "from": "async@~0.9.0"
                             }
                           }
                         },
                         "json-stringify-safe": {
                           "version": "5.0.0",
-                          "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-                          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                          "from": "json-stringify-safe@~5.0.0"
                         },
                         "mime-types": {
-                          "version": "1.0.2",
-                          "from": "mime-types@>=1.0.1 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                          "version": "2.0.9",
+                          "from": "mime-types@~2.0.1",
+                          "dependencies": {
+                            "mime-db": {
+                              "version": "1.7.0",
+                              "from": "mime-db@~1.7.0"
+                            }
+                          }
                         },
                         "node-uuid": {
                           "version": "1.4.2",
-                          "from": "node-uuid@>=1.4.0 <1.5.0",
-                          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+                          "from": "node-uuid@~1.4.0"
                         },
                         "qs": {
                           "version": "2.3.3",
-                          "from": "qs@>=2.3.1 <2.4.0",
-                          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                          "from": "qs@~2.3.1"
                         },
                         "tunnel-agent": {
                           "version": "0.4.0",
-                          "from": "tunnel-agent@>=0.4.0 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                          "from": "tunnel-agent@~0.4.0"
                         },
                         "tough-cookie": {
                           "version": "0.12.1",
                           "from": "tough-cookie@>=0.12.0",
-                          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
                           "dependencies": {
                             "punycode": {
                               "version": "1.3.2",
-                              "from": "punycode@>=0.2.0",
-                              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                              "from": "punycode@>=0.2.0"
                             }
                           }
                         },
                         "http-signature": {
                           "version": "0.10.1",
-                          "from": "http-signature@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                          "from": "http-signature@~0.10.0",
                           "dependencies": {
                             "assert-plus": {
                               "version": "0.1.5",
-                              "from": "assert-plus@>=0.1.5 <0.2.0"
+                              "from": "assert-plus@^0.1.5"
                             },
                             "asn1": {
                               "version": "0.1.11",
-                              "from": "asn1@0.1.11",
-                              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                              "from": "asn1@0.1.11"
                             },
                             "ctype": {
                               "version": "0.5.3",
-                              "from": "ctype@0.5.3",
-                              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                              "from": "ctype@0.5.3"
                             }
                           }
                         },
                         "oauth-sign": {
-                          "version": "0.5.0",
-                          "from": "oauth-sign@>=0.5.0 <0.6.0",
-                          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
-                        },
-                        "hawk": {
-                          "version": "1.1.1",
-                          "from": "hawk@1.1.1",
-                          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-                          "dependencies": {
-                            "hoek": {
-                              "version": "0.9.1",
-                              "from": "hoek@>=0.9.0 <0.10.0",
-                              "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
-                            },
-                            "boom": {
-                              "version": "0.4.2",
-                              "from": "boom@>=0.4.0 <0.5.0"
-                            },
-                            "cryptiles": {
-                              "version": "0.2.2",
-                              "from": "cryptiles@>=0.2.0 <0.3.0"
-                            },
-                            "sntp": {
-                              "version": "0.2.4",
-                              "from": "sntp@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
-                            }
-                          }
+                          "version": "0.6.0",
+                          "from": "oauth-sign@~0.6.0"
                         },
                         "aws-sign2": {
                           "version": "0.5.0",
-                          "from": "aws-sign2@>=0.5.0 <0.6.0",
-                          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                          "from": "aws-sign2@~0.5.0"
                         },
                         "stringstream": {
                           "version": "0.0.4",
-                          "from": "stringstream@>=0.0.4 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                          "from": "stringstream@~0.0.4"
                         },
                         "combined-stream": {
                           "version": "0.0.7",
-                          "from": "combined-stream@>=0.0.5 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                          "from": "combined-stream@~0.0.5",
                           "dependencies": {
                             "delayed-stream": {
                               "version": "0.0.5",
-                              "from": "delayed-stream@0.0.5",
-                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                              "from": "delayed-stream@0.0.5"
                             }
                           }
+                        },
+                        "isstream": {
+                          "version": "0.1.1",
+                          "from": "isstream@~0.1.1"
                         }
                       }
                     },
                     "xmlhttprequest": {
                       "version": "1.7.0",
-                      "from": "xmlhttprequest@>=1.5.0",
-                      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.7.0.tgz"
+                      "from": "xmlhttprequest@>=1.5.0"
                     },
                     "cssom": {
                       "version": "0.3.0",
-                      "from": "cssom@>=0.3.0 <0.4.0"
+                      "from": "cssom@~0.3.0"
                     },
                     "cssstyle": {
                       "version": "0.2.22",
-                      "from": "cssstyle@>=0.2.9 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.22.tgz"
+                      "from": "cssstyle@~0.2.9"
                     },
                     "contextify": {
-                      "version": "0.1.12",
-                      "from": "contextify@>=0.1.5 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/contextify/-/contextify-0.1.12.tgz",
+                      "version": "0.1.13",
+                      "from": "contextify@~0.1.5",
                       "dependencies": {
                         "bindings": {
                           "version": "1.2.1",
-                          "from": "bindings@*",
-                          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
+                          "from": "bindings@*"
                         },
                         "nan": {
-                          "version": "1.3.0",
-                          "from": "nan@>=1.3.0 <1.4.0",
-                          "resolved": "https://registry.npmjs.org/nan/-/nan-1.3.0.tgz"
+                          "version": "1.5.3",
+                          "from": "nan@~1.5.0"
                         }
                       }
                     }
@@ -2245,61 +1981,50 @@
                 "primus": {
                   "version": "2.4.12",
                   "from": "primus@*",
-                  "resolved": "https://registry.npmjs.org/primus/-/primus-2.4.12.tgz",
                   "dependencies": {
                     "access-control": {
                       "version": "0.0.7",
-                      "from": "access-control@>=0.0.0 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/access-control/-/access-control-0.0.7.tgz",
+                      "from": "access-control@0.0.x",
                       "dependencies": {
                         "millisecond": {
                           "version": "0.0.1",
-                          "from": "millisecond@>=0.0.0 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/millisecond/-/millisecond-0.0.1.tgz"
+                          "from": "millisecond@0.0.x"
                         },
                         "vary": {
                           "version": "1.0.0",
-                          "from": "vary@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
+                          "from": "vary@1.0.x"
                         }
                       }
                     },
                     "create-server": {
                       "version": "0.0.7",
-                      "from": "create-server@>=0.0.0 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/create-server/-/create-server-0.0.7.tgz",
+                      "from": "create-server@0.0.x",
                       "dependencies": {
                         "connected": {
                           "version": "0.0.2",
-                          "from": "connected@>=0.0.0 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/connected/-/connected-0.0.2.tgz"
+                          "from": "connected@0.0.x"
                         }
                       }
                     },
                     "diagnostics": {
                       "version": "0.0.4",
-                      "from": "diagnostics@>=0.0.0 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-0.0.4.tgz",
+                      "from": "diagnostics@0.0.x",
                       "dependencies": {
                         "color": {
                           "version": "0.7.3",
-                          "from": "color@>=0.7.0 <0.8.0",
-                          "resolved": "https://registry.npmjs.org/color/-/color-0.7.3.tgz",
+                          "from": "color@0.7.x",
                           "dependencies": {
                             "color-convert": {
                               "version": "0.5.2",
-                              "from": "color-convert@>=0.5.0 <0.6.0",
-                              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.2.tgz"
+                              "from": "color-convert@0.5.x"
                             },
                             "color-string": {
                               "version": "0.2.4",
-                              "from": "color-string@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.2.4.tgz",
+                              "from": "color-string@0.2.x",
                               "dependencies": {
                                 "color-name": {
                                   "version": "1.0.0",
-                                  "from": "color-name@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.0.0.tgz"
+                                  "from": "color-name@1.0.x"
                                 }
                               }
                             }
@@ -2307,55 +2032,45 @@
                         },
                         "colornames": {
                           "version": "0.0.2",
-                          "from": "colornames@>=0.0.0 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz"
+                          "from": "colornames@0.0.x"
                         },
                         "env-variable": {
                           "version": "0.0.3",
-                          "from": "env-variable@>=0.0.0 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.3.tgz"
+                          "from": "env-variable@0.0.x"
                         },
                         "kuler": {
                           "version": "0.0.0",
-                          "from": "kuler@>=0.0.0 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz"
+                          "from": "kuler@0.0.x"
                         },
                         "text-hex": {
                           "version": "0.0.0",
-                          "from": "text-hex@>=0.0.0 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz"
+                          "from": "text-hex@0.0.x"
                         }
                       }
                     },
                     "eventemitter3": {
                       "version": "0.1.6",
-                      "from": "eventemitter3@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.6.tgz"
+                      "from": "eventemitter3@0.1.x"
                     },
                     "forwarded-for": {
                       "version": "0.1.1",
-                      "from": "forwarded-for@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/forwarded-for/-/forwarded-for-0.1.1.tgz"
+                      "from": "forwarded-for@0.1.x"
                     },
                     "fusing": {
                       "version": "0.4.0",
-                      "from": "fusing@>=0.4.0 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/fusing/-/fusing-0.4.0.tgz",
+                      "from": "fusing@0.4.x",
                       "dependencies": {
                         "emits": {
                           "version": "1.0.2",
-                          "from": "emits@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/emits/-/emits-1.0.2.tgz"
+                          "from": "emits@1.0.x"
                         },
                         "predefine": {
                           "version": "0.1.2",
-                          "from": "predefine@>=0.1.0 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/predefine/-/predefine-0.1.2.tgz",
+                          "from": "predefine@0.1.x",
                           "dependencies": {
                             "extendible": {
                               "version": "0.1.0",
-                              "from": "extendible@>=0.1.0 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/extendible/-/extendible-0.1.0.tgz"
+                              "from": "extendible@0.1.x"
                             }
                           }
                         }
@@ -2363,52 +2078,44 @@
                     },
                     "load": {
                       "version": "1.0.1",
-                      "from": "load@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/load/-/load-1.0.1.tgz"
+                      "from": "load@1.0.x"
                     },
                     "setheader": {
                       "version": "0.0.4",
-                      "from": "setheader@>=0.0.0 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/setheader/-/setheader-0.0.4.tgz",
+                      "from": "setheader@0.0.x",
                       "dependencies": {
                         "debug": {
                           "version": "0.7.4",
-                          "from": "debug@>=0.7.0 <0.8.0",
-                          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                          "from": "debug@0.7.x"
                         }
                       }
                     },
                     "ultron": {
                       "version": "1.0.1",
-                      "from": "ultron@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.1.tgz"
+                      "from": "ultron@1.0.x"
                     }
                   }
                 },
                 "ws": {
                   "version": "0.4.32",
-                  "from": "ws@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
+                  "from": "ws@0.4.x",
                   "dependencies": {
                     "commander": {
                       "version": "2.1.0",
-                      "from": "commander@>=2.1.0 <2.2.0",
+                      "from": "commander@~2.1.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
                     },
                     "nan": {
                       "version": "1.0.0",
-                      "from": "nan@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz"
+                      "from": "nan@~1.0.0"
                     },
                     "tinycolor": {
                       "version": "0.0.1",
-                      "from": "tinycolor@>=0.0.0 <1.0.0",
-                      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
+                      "from": "tinycolor@0.x"
                     },
                     "options": {
                       "version": "0.0.6",
-                      "from": "options@>=0.0.5",
-                      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                      "from": "options@>=0.0.5"
                     }
                   }
                 }
@@ -2432,18 +2139,6 @@
       "version": "2.0.1",
       "from": "uuid@2.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
-    },
-    "xml2js": {
-      "version": "0.4.4",
-      "from": "xml2js@>=0.4.4 <0.5.0",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.4.tgz",
-      "dependencies": {
-        "sax": {
-          "version": "0.6.1",
-          "from": "sax@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz"
-        }
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "aws-sdk": "2.0.19",
     "aws-sdk-promise": "0.0.0",
-    "azure-storage": "0.4.2",
+    "azure-storage": "^0.4.2",
     "cryptiles": "2.0.4",
     "debug": "2.1.1",
     "knex": "0.7.3",

--- a/queue/blobstore.js
+++ b/queue/blobstore.js
@@ -25,7 +25,6 @@ var BlobStore = function(options) {
     options.credentials.accountName,
     options.credentials.accountKey
   ).withFilter(new azure.ExponentialRetryPolicyFilter());
-  debug("optoins: %j", options);
 };
 
 // Export BlobStore
@@ -34,12 +33,9 @@ module.exports = BlobStore;
 /** Create blob-store container */
 BlobStore.prototype.createContainer = function() {
   var that = this;
-  debug("Creating container: %s", that.container);
   return new Promise(function(accept, reject) {
-    debug("Got here");
     that.service.createContainerIfNotExists(that.container,
                                             function(err, created) {
-      debug("Got here2");
       if (err) {
         debug("Failed to create container '%s', err: %s, as JSON: %j",
               that.container, err, err);
@@ -52,7 +48,6 @@ BlobStore.prototype.createContainer = function() {
       }
       return accept(created);
     });
-    debug("Got here3");
   });
 };
 

--- a/queue/blobstore.js
+++ b/queue/blobstore.js
@@ -25,6 +25,7 @@ var BlobStore = function(options) {
     options.credentials.accountName,
     options.credentials.accountKey
   ).withFilter(new azure.ExponentialRetryPolicyFilter());
+  debug("optoins: %j", options);
 };
 
 // Export BlobStore
@@ -33,9 +34,12 @@ module.exports = BlobStore;
 /** Create blob-store container */
 BlobStore.prototype.createContainer = function() {
   var that = this;
+  debug("Creating container: %s", that.container);
   return new Promise(function(accept, reject) {
+    debug("Got here");
     that.service.createContainerIfNotExists(that.container,
                                             function(err, created) {
+      debug("Got here2");
       if (err) {
         debug("Failed to create container '%s', err: %s, as JSON: %j",
               that.container, err, err);
@@ -48,6 +52,7 @@ BlobStore.prototype.createContainer = function() {
       }
       return accept(created);
     });
+    debug("Got here3");
   });
 };
 

--- a/routes/api/v1.js
+++ b/routes/api/v1.js
@@ -902,8 +902,8 @@ api.declare({
   }).then(function(result) {
     // Return the "error" message if we have one
     if(!(result instanceof ctx.Task)) {
-      return res.status(409).json(result.code, {
-        message:      result.message
+      return res.status(result.code).json({
+        message:      result.message,
       });
     }
 

--- a/schemas/pending-tasks-response.yml
+++ b/schemas/pending-tasks-response.yml
@@ -1,0 +1,38 @@
+id:         http://schemas.taskcluster.net/queue/v1/pending-tasks-response.json
+$schema:    http://json-schema.org/draft-04/schema#
+title:              "Count Pending Tasks Response"
+description: |
+  Response to a request for the number of pending tasks for a given
+  `provisionerId` and `workerType`.
+type:               object
+properties:
+  provisionerId:
+    title:          "Provisioner Id"
+    description: |
+      Unique identifier for the provisioner
+    type:           string
+    minLength:      {$const: identifier-min-length}
+    maxLength:      {$const: identifier-max-length}
+    pattern:        {$const: identifier-pattern}
+  workerType:
+    title:          "Worker Type"
+    description: |
+      Identifier for worker type within the specified provisioner
+    type:           string
+    minLength:      {$const: identifier-min-length}
+    maxLength:      {$const: identifier-max-length}
+    pattern:        {$const: identifier-pattern}
+  pendingTasks:
+    type:           integer
+    minimum:        0
+    title:          "Number of Pending Tasks"
+    description: |
+      An approximate number of pending tasks for the given `provisionerId` and
+      `workerType`. This is based on Azure Queue Storage meta-data API, thus,
+      number of reported here may be higher than actual number of pending tasks.
+      But there cannot be more pending tasks reported here. Ie. this is an
+      **upper-bound** on the number of pending tasks.
+required:
+  - provisionerId
+  - workerType
+  - pendingTasks

--- a/schemas/poll-task-urls-response.yml
+++ b/schemas/poll-task-urls-response.yml
@@ -5,27 +5,57 @@ description: |
   Response to request for poll task urls.
 type:           object
 properties:
-  signedPollTaskUrls:
+  queues:
     type:       array
+    title:      "Queues To Poll From"
     description: |
-      List of signed URLs to poll tasks from, they must be called in the order
-      they are given. As the first entry in this array **may** have higher
-      priority.
+      List of signed URLs for queues to poll tasks from, they must be called
+      in the order they are given. As the first entry in this array **may**
+      have higher priority.
     items:
-      type:       string
-      format:     uri
-      title:      "Signed Get Message URL"
+      type:       object
+      title:      "Signed URLs for a queue"
       description: |
-        Signed URL to get message from the Azure Queue Storage queue, that holds
-        messages for the given `provisionerId` and `workerType`. Note that this
-        URL returns XML, see documentation for the Azure Queue Storage
-        [REST API](http://msdn.microsoft.com/en-us/library/azure/dd179474.aspx)
-        for details. When you have a message you can use `claimTask` to claim
-        the task. You will need to parse the XML reponse and base64 decode and
-        JSON parse the `MessageText`, also note that `claimTask` requires
-        the `PopReceipt` and `MessageId`.
-        **Remark**, you are allowed to append `&numofmessages=N`, where N < 32,
-        to the URLs if you wish to obtain more than one message at the time.
+        Object holding two signed URLs for an azure queue, one for fetching
+        messages, and another for deleting messages. Remember to `claimTask`
+        before deleting the message, and delete message even if the `claimTask`
+        operation fails with a 400 status code. Don't delete it on other status
+        codes!
+      properties:
+        signedPollUrl:
+          type:     string
+          format:   uri
+          title:    "Signed Get Message URL"
+          description: |
+            Signed URL to get message from the Azure Queue Storage queue,
+            that holds messages for the given `provisionerId` and `workerType`.
+            Note that this URL returns XML, see documentation for the Azure
+            Queue Storage
+            [REST API](http://msdn.microsoft.com/en-us/library/azure/dd179474.aspx)
+            for details.
+            When you have a message you can use `claimTask` to claim the task.
+            You will need to parse the XML reponse and base64 decode and
+            JSON parse the `MessageText`.
+            After you have called `claimTask` you **must** us the
+            `signedDeleteUrl` to delete the message.
+            **Remark**, you are allowed to append `&numofmessages=N`,
+            where N < 32, to the URLs if you wish to obtain more than one
+            message at the time.
+        signedDeleteUrl:
+          type:     string
+          format:   uri
+          title:    "Signed Delete Message URL"
+          description: |
+            Signed URL to delete messages that have been received using the
+            `signedPollUrl`. You **must** do this to avoid receiving the same
+            message again.
+            To use this URL you must substitute `{{messageId}}` and
+            `{{popReceipt}}` with `MessageId` and `PopReceipt` from the XML
+            response the `signedPollUrl` gave you. Note this URL only works
+            with `DELETE` request.
+      required:
+        - signedPollUrl
+        - signedDeleteUrl
   expires:
     title:    "Signed URL Expiration"
     description: |
@@ -34,5 +64,5 @@ properties:
     type:         string
     format:       date-time
 required:
-  - signedPollTaskUrls
+  - queues
   - expires

--- a/schemas/task.yml
+++ b/schemas/task.yml
@@ -69,7 +69,7 @@ properties:
       these events are to be expected.
     type:           integer
     minimum:        0
-    maximum:        50
+    maximum:        49
   created:          {$const: created}
   deadline:         {$const: deadline}
   scopes:

--- a/test/api/claimtask_test.js
+++ b/test/api/claimtask_test.js
@@ -130,6 +130,30 @@ suite('Claim task', function() {
     });
   });
 
+
+  test("can claimWork (empty queue)", function() {
+    var taskId = slugid.v4();
+    // Create datetime for created and deadline as 3 days later
+    var created = new Date();
+    var deadline = new Date();
+    deadline.setDate(created.getDate() + 3);
+    return helper.queue.createTask(taskId, taskDef).then(function() {
+      // Reduce scopes available to test minimum set of scopes required
+      helper.scopes(
+        'queue:claim-task',
+        'assume:worker-type:my-provisioner/my-other-worker',
+        'assume:worker-id:my-worker-group/my-other-worker'
+      );
+      // First runId is always 0, so we should be able to claim it here
+      return helper.queue.claimWork('my-provisioner', 'my-other-worker', {
+        workerGroup:    'my-worker-group',
+        workerId:       'my-other-worker'
+      });
+    }).then(function(result) {
+      assert(!result.status, "Expected not to get a status");
+    });
+  });
+
   test("claimTask requires scopes", function() {
     var taskId = slugid.v4();
     return helper.queue.createTask(taskId, taskDef).then(function() {

--- a/test/api/querytasks_test.js
+++ b/test/api/querytasks_test.js
@@ -69,4 +69,13 @@ suite('Query tasks', function() {
       assert(result.pendingTasks === 2, "Expected two tasks from my-worker");
     });
   });
+
+  test("pendingTasks (zero pending tasks)", function() {
+    return helper.queue.pendingTasks(
+      'my-provisioner',
+      'empty-worker'
+    ).then(function(result) {
+      assert(result.pendingTasks === 0, "Expected 0 tasks from empty-worker");
+    });
+  });
 });

--- a/test/api/querytasks_test.js
+++ b/test/api/querytasks_test.js
@@ -66,7 +66,7 @@ suite('Query tasks', function() {
     }).then(function() {
       return helper.queue.pendingTasks('my-provisioner', 'my-worker');
     }).then(function(result) {
-      assert(result === 2, "Expected two tasks from my-worker");
+      assert(result.pendingTasks === 2, "Expected two tasks from my-worker");
     });
   });
 });


### PR DESCRIPTION
  * Marked everything deprecated accordingly
  * Updated JSON schemas to match what we will have in the future

Shouldn't break compatibility, but allow migration to the new poll-flow, as documented:
http://docs.taskcluster.net/queue/worker-interaction/