### PR TITLE
Use  for exception run

### DIFF
--- a/queue/deadlineresolver.js
+++ b/queue/deadlineresolver.js
@@ -147,11 +147,14 @@ class DeadlineResolver {
 
     // Ensure that all runs are resolved
     await task.modify((task) => {
+      // If there is no run, we add a new one to signal that the task is
+      // resolved. As this run is purely to signal an exception, we set
+      // `reasonCreated: 'exception'`.
       if (task.runs.length === 0) {
         var now = new Date().toJSON();
         task.runs.push({
           state:            'exception',
-          reasonCreated:    'scheduled',
+          reasonCreated:    'exception',
           reasonResolved:   'deadline-exceeded',
           scheduled:        now,
           resolved:         now

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -898,15 +898,14 @@ api.declare({
     }
 
     // If the task wasn't scheduled, we'll add a run and resolved it canceled.
-    // This is the equivalent of calling scheduleTask and cancelTask, ie.
-    // the resulting run state is the same as that of a canceled pending run
-    // in that the run doesn't have a `started` time, nor a `workerGroup` or
-    // `workerId`.
+    // This is almost equivalent to calling scheduleTask and cancelTask, but
+    // instead of setting `reasonCreated` to 'scheduled', we set it 'exception',
+    // because this run was made solely to communicate an exception.
     if (state === 'unscheduled') {
       var now = new Date().toJSON();
       task.runs.push({
         state:            'exception',
-        reasonCreated:    'scheduled',
+        reasonCreated:    'exception',
         reasonResolved:   'canceled',
         scheduled:        now,
         resolved:         now

--- a/schemas/task-status.yml
+++ b/schemas/task-status.yml
@@ -103,6 +103,7 @@ properties:
             - scheduled
             - retry
             - rerun
+            - exception
         reasonResolved:
           title:          "Reason Resolved"
           description: |

--- a/test/api/canceltask_test.js
+++ b/test/api/canceltask_test.js
@@ -49,6 +49,7 @@ suite('Rerun task', function() {
     expect(r2.status.state).to.be('exception');
     expect(r2.status.runs.length).to.be(1);
     expect(r2.status.runs[0].state).to.be('exception');
+    expect(r2.status.runs[0].reasonCreated).to.be('exception');
     expect(r2.status.runs[0].reasonResolved).to.be('canceled');
 
     var m1 = await helper.events.waitFor('except');
@@ -78,6 +79,7 @@ suite('Rerun task', function() {
     expect(r2.status.state).to.be('exception');
     expect(r2.status.runs.length).to.be(1);
     expect(r2.status.runs[0].state).to.be('exception');
+    expect(r2.status.runs[0].reasonCreated).to.be('scheduled');
     expect(r2.status.runs[0].reasonResolved).to.be('canceled');
 
     var m1 = await helper.events.waitFor('except');
@@ -114,6 +116,7 @@ suite('Rerun task', function() {
     expect(r3.status.state).to.be('exception');
     expect(r3.status.runs.length).to.be(1);
     expect(r3.status.runs[0].state).to.be('exception');
+    expect(r3.status.runs[0].reasonCreated).to.be('scheduled');
     expect(r3.status.runs[0].reasonResolved).to.be('canceled');
 
     var m1 = await helper.events.waitFor('except');

--- a/test/api/deadline_test.js
+++ b/test/api/deadline_test.js
@@ -49,6 +49,7 @@ suite('Deadline expiration (deadline-reaper)', function() {
     var m1 = await helper.events.waitFor('except');
     expect(m1.payload.status.state).to.be('exception');
     expect(m1.payload.status.runs.length).to.be(1);
+    expect(m1.payload.status.runs[0].reasonCreated).to.be('exception');
     expect(m1.payload.status.runs[0].reasonResolved).to.be('deadline-exceeded');
 
     debug("### Stop deadlineReaper");
@@ -78,6 +79,7 @@ suite('Deadline expiration (deadline-reaper)', function() {
     var m1 = await helper.events.waitFor('except');
     expect(m1.payload.status.state).to.be('exception');
     expect(m1.payload.status.runs.length).to.be(1);
+    expect(m1.payload.status.runs[0].reasonCreated).to.be('scheduled');
     expect(m1.payload.status.runs[0].reasonResolved).to.be('deadline-exceeded');
 
     debug("### Stop deadlineReaper");
@@ -113,6 +115,7 @@ suite('Deadline expiration (deadline-reaper)', function() {
     var m1 = await helper.events.waitFor('except');
     expect(m1.payload.status.state).to.be('exception');
     expect(m1.payload.status.runs.length).to.be(1);
+    expect(m1.payload.status.runs[0].reasonCreated).to.be('scheduled');
     expect(m1.payload.status.runs[0].reasonResolved).to.be('deadline-exceeded');
 
     debug("### Stop deadlineReaper");


### PR DESCRIPTION
From [bug 1148965](https://bugzilla.mozilla.org/show_bug.cgi?id=1148965).

>   A) Set {reasonCreated: 'exception'}, if a run was created solely for one of the two cases:
     1) task canceled before first run was scheduled
     2) deadline expired before first run was schedule