### PR TITLE
Allow artifact creation past resolution as exception

### DIFF
--- a/routes/artifacts.js
+++ b/routes/artifacts.js
@@ -173,7 +173,12 @@ api.declare({
     }
     if (!allow) {
       return res.status(409).json({
-        message:    "The given run is not running",
+        message:    "Artifacts cannot be created for a task after it is " +
+                    "resolved, unless it is resolved 'exception', and even " +
+                    "in this case only up to 25 min past resolution." +
+                    "This to ensure that artifacts have been uploaded before " +
+                    "a task is 'completed' and output is consumed by a " +
+                    "dependent task",
         error: {
           status:   task.status(),
           runId:    runId

--- a/routes/artifacts.js
+++ b/routes/artifacts.js
@@ -163,13 +163,23 @@ api.declare({
 
   // Ensure that the run is running
   if (run.state !== 'running') {
-    return res.status(409).json({
-      message:    "The given run is not running",
-      error: {
-        status:   task.status(),
-        runId:    runId
-      }
-    });
+    var allow = false;
+    if (run.state === 'exception') {
+      // If task was resolved exception, we'll allow artifacts to be uploaded
+      // up to 25 min past resolution. This allows us to report exception as
+      // soon as we know and then upload logs if possible.
+      // Useful because exception usually implies something badly wrong.
+      allow = (new Date(run.resolved).getTime() > Date.now() - 25 * 60 * 1000);
+    }
+    if (!allow) {
+      return res.status(409).json({
+        message:    "The given run is not running",
+        error: {
+          status:   task.status(),
+          runId:    runId
+        }
+      });
+    }
   }
 
   // Construct details for different storage types


### PR DESCRIPTION
Allow artifact creation past task resolution if resolved as `exception`.

Generally, tasks resolved as exception aren't being resolved in a calm and orderly fashion, and any resulting artifact or log is a best-effort service.