### PR TITLE
Fix queue collisions

### DIFF
--- a/bin/expire-queues.js
+++ b/bin/expire-queues.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+var debug         = require('debug')('queue:bin:expire-queues');
+var base          = require('taskcluster-base');
+var path          = require('path');
+var assert        = require('assert');
+var QueueService  = require('../queue/queueservice');
+
+/** Launch expire-queues */
+var launch = async function(profile) {
+  debug("Launching with profile: %s", profile);
+
+  // Load configuration
+  var cfg = base.config({
+    defaults:     require('../config/defaults'),
+    profile:      require('../config/' + profile),
+    envs: [
+      'pulse_username',
+      'pulse_password',
+      'queue_publishMetaData',
+      'taskcluster_credentials_clientId',
+      'taskcluster_credentials_accessToken',
+      'aws_accessKeyId',
+      'aws_secretAccessKey',
+      'azure_accountName',
+      'azure_accountKey',
+      'influx_connectionString'
+    ],
+    filename:     'taskcluster-queue'
+  });
+
+  // Create InfluxDB connection for submitting statistics
+  var influx = new base.stats.Influx({
+    connectionString:   cfg.get('influx:connectionString'),
+    maxDelay:           cfg.get('influx:maxDelay'),
+    maxPendingPoints:   cfg.get('influx:maxPendingPoints')
+  });
+
+  // Start monitoring the process
+  base.stats.startProcessUsageReporting({
+    drain:      influx,
+    component:  cfg.get('queue:statsComponent'),
+    process:    'expire-queues'
+  });
+
+  // Create QueueService to manage azure queues
+  var queueService = new QueueService({
+    prefix:           cfg.get('queue:queuePrefix'),
+    credentials:      cfg.get('azure'),
+    claimQueue:       cfg.get('queue:claimQueue'),
+    deadlineQueue:    cfg.get('queue:deadlineQueue'),
+    deadlineDelay:    cfg.get('queue:deadlineDelay')
+  });
+
+  // Notify parent process, so that this worker can run using LocalApp
+  base.app.notifyLocalAppInParentProcess();
+
+  // Expire queues
+  debug("Expiring queues at: %s", new Date());
+  var count = await queueService.deleteUnusedWorkerQueues();
+  debug("Expired %s queues", count);
+
+  // Stop recording statistics and send any stats that we have
+  base.stats.stopProcessUsageReporting();
+  return influx.close();
+};
+
+// If expire-queues.js is executed run launch
+if (!module.parent) {
+  // Find configuration profile
+  var profile = process.argv[2];
+  if (!profile) {
+    console.log("Usage: expire-queues.js [profile]")
+    console.error("ERROR: No configuration profile is provided");
+  }
+  // Launch with given profile
+  launch(profile).then(function() {
+    debug("Expired queues successfully");
+    // Close the process we're done now
+    process.exit(0);
+  }).catch(function(err) {
+    debug("Failed to start expire-queues, err: %s, as JSON: %j",
+          err, err, err.stack);
+    // If we didn't launch the expire-queues we should crash
+    process.exit(1);
+  });
+}
+
+// Export launch in-case anybody cares
+module.exports = launch;

--- a/config/test.js
+++ b/config/test.js
@@ -8,6 +8,7 @@ module.exports = {
     artifactContainer:            'artifacts',
     statsComponent:               'test-queue',
     queuePrefix:                  'hacks',
+    queuePrefix2:                 'hacks2', // For testing deletion of queues
     taskTableName:                'TestTasks',
     artifactTableName:            'TestArtifacts',
     claimQueue:                   'test-claim-queue',

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lodash":               "^3.6.0",
     "promise":              "6.1.0",
     "slugid":               "1.0.3",
-    "taskcluster-base":     "0.7.23",
+    "taskcluster-base":     "0.7.25",
     "thirty-two":           "^0.0.2",
     "url-join":             "0.0.1",
     "uuid":                 "2.0.1",
@@ -35,7 +35,7 @@
     "xml2js":               "^0.4.6",
     "request-ip":           "^1.1.3",
     "netmask":              "^1.0.5",
-    "fast-azure-storage":   "^0.1.1"
+    "fast-azure-storage":   "^0.1.2"
   },
   "devDependencies": {
     "mocha":                "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "kexec":                "^1.2.0",
     "superagent":           "^1.1.0",
     "superagent-promise":   "^0.2.0",
-    "azure-queue-node":     "^1.1.0",
     "xml2js":               "^0.4.6",
     "request-ip":           "^1.1.3",
     "netmask":              "^1.0.5",

--- a/queue/queueservice.js
+++ b/queue/queueservice.js
@@ -392,10 +392,14 @@ class QueueService {
     }
   }
 
-  /** Remove all worker queues not used since `now - 10 days` */
+  /**
+   * Remove all worker queues not used since `now - 10 days`.
+   * Returns number of queues deleted.
+   */
   async deleteUnusedWorkerQueues(now = new Date()) {
     assert(now instanceof Date, "Expected now as Date object");
     let deleteIfNotUsedSince = now.getTime() - 10 * 24 * 60 * 60 * 1000;
+    let deleted = 0; // Number of queues deleted
 
     // Iterate through all pages
     let marker = undefined;
@@ -431,11 +435,17 @@ class QueueService {
         }
 
         debug("Deleting queue %s with metadata: %j", name, metadata);
-        return this.client.deleteQueue(name);
+        await this.client.deleteQueue(name);
+
+        // Count queues deleted (for test ability)
+        deleted += 1;
       }));
 
       // Keep going until we get an `undefined` marker
     } while (marker);
+
+    // Return number of queues deleted
+    return deleted;
   }
 
 

--- a/queue/queueservice.js
+++ b/queue/queueservice.js
@@ -431,7 +431,7 @@ class QueueService {
         // Fetch message count (approximate)
         let {messageCount} = await this.client.getMetadata(name);
         if (messageCount > 0) {
-          return; // Abort if there is messages
+          return; // Abort if there are messages
         }
 
         debug("Deleting queue %s with metadata: %j", name, metadata);
@@ -526,7 +526,7 @@ class QueueService {
 
     // For each queue name, return signed URLs for the queue
     var queues = [
-      legacyName, // Return legacy queue first, so we it emptied
+      legacyName, // Return legacy queue first, so empty it first
       queueName
     ].map(queueName => {
       // Create shared access signature

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -979,20 +979,14 @@ api.declare({
   // Construct signedUrl for accessing the azure queue for this
   // provisionerId and workerType
   var {
-    signedPollUrl,
-    signedDeleteUrl,
+    queues,
     expiry
-  } = await this.queueService.signedPendingPollUrl(provisionerId, workerType);
+  } = await this.queueService.signedPendingPollUrls(provisionerId, workerType);
 
   // Return signed URLs
   res.reply({
-    queues: [
-      {
-        signedPollUrl:        signedPollUrl,
-        signedDeleteUrl:      signedDeleteUrl
-      }
-    ],
-    expires:                  expiry.toJSON()
+    queues,
+    expires: expiry.toJSON()
   });
 });
 

--- a/test/api/expirequeues_test.js
+++ b/test/api/expirequeues_test.js
@@ -1,0 +1,20 @@
+suite('Task Expiration (expire-tasks)', () => {
+  var debug       = require('debug')('test:api:expireTasks');
+  var assert      = require('assert');
+  var slugid      = require('slugid');
+  var _           = require('lodash');
+  var Promise     = require('promise');
+  var taskcluster = require('taskcluster-client');
+  var base        = require('taskcluster-base');
+  var assume      = require('assume');
+  var helper      = require('./helper');
+
+  // test functionality elsewhere, here we just test that it can actually run
+  test("expire-queues runs without bugs", async () => {
+    // We don't care if we delete any queues. In fact we won't delete queues
+    // used in testing because they have up-to-date meta-data. Also if we did
+    // they would be in state queue-being-deleted (so tests would fail)
+    debug("### Expire queues (don't care if delete any)");
+    await helper.expireQueues();
+  });
+});

--- a/test/api/helper.js
+++ b/test/api/helper.js
@@ -11,6 +11,7 @@ var bin = {
   server:             require('../../bin/server'),
   expireArtifacts:    require('../../bin/expire-artifacts'),
   expireTasks:        require('../../bin/expire-tasks'),
+  expireQueues:       require('../../bin/expire-queues'),
   claimReaper:        require('../../bin/claim-reaper'),
   deadlineReaper:     require('../../bin/deadline-reaper')
 };
@@ -69,6 +70,11 @@ helper.expireArtifacts = () => {
 // Allow tests to run expire-tasks
 helper.expireTasks = () => {
   return bin.expireTasks(testProfile);
+};
+
+// Allow tests to run expire-queues
+helper.expireQueues = () => {
+  return bin.expireQueues(testProfile);
 };
 
 // Process to terminate

--- a/test/queue/queueservice_test.js
+++ b/test/queue/queueservice_test.js
@@ -9,6 +9,7 @@ suite('queue/QueueService', function() {
   var request       = require('superagent-promise');
   var debug         = require('debug')('queue:test:queueservice');
   var xml2js        = require('xml2js');
+  var assume        = require('assume');
 
   // Load configuration
   var cfg = base.config({
@@ -73,7 +74,7 @@ suite('queue/QueueService', function() {
     var takenUntil  = new Date(new Date().getTime() + 2 * 1000);
     debug("Putting message with taskId: %s", taskId);
     // Put message
-    await queueService.putClaimMessage(taskId, takenUntil);
+    await queueService.putClaimMessage(taskId, 0, takenUntil);
 
     // Poll for message
     return base.testing.poll(async () => {
@@ -110,9 +111,13 @@ suite('queue/QueueService', function() {
 
     // Get signedPollUrl and signedDeleteUrl
     var {
-      signedPollUrl,
-      signedDeleteUrl
-    } = await queueService.signedPendingPollUrl(provisionerId, workerType);
+      queues: [
+        {}, {
+          signedPollUrl,
+          signedDeleteUrl
+        }
+      ]
+    } = await queueService.signedPendingPollUrls(provisionerId, workerType);
 
     // Get a message
     debug("### Polling for queue for message");

--- a/test/queue/queueservice_test.js
+++ b/test/queue/queueservice_test.js
@@ -172,7 +172,7 @@ suite('queue/QueueService', function() {
     assert(typeof(count) === 'number', "Expected count as number!");
   });
 
-  test("deleteUnusedWorkerQueues", async () => {
+  test("deleteUnusedWorkerQueues (can delete queues)", async () => {
     // 11 days into the future, so we'll delete all queues (yay)
     let now = new Date(Date.now() + 11 * 24 * 60 * 60 * 1000);
     let deleted = await queueService.deleteUnusedWorkerQueues(now);
@@ -181,6 +181,21 @@ suite('queue/QueueService', function() {
     assume(deleted).is.atleast(1);
   });
 
+
+  test("deleteUnusedWorkerQueues (respects meta-data)", async () => {
+    // Ensure a queue with updated meta-data exists
+    let provisionerId = slugid.v4();
+    let workerType = slugid.v4();
+    let queueName = await queueService.ensurePendingQueue(
+      provisionerId, workerType
+    );
+
+    // Let's delete from now and check that we didn't delete queue just created
+    await queueService.deleteUnusedWorkerQueues();
+
+    // Get meta-data, this will fail if the queue was deleted
+    await queueService.client.getMetadata(queueName);
+  });
 
   // TODO: Remove this test case when legacy queues are phased out
   test("Update meta-data of legacy queue", async () => {

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -6,6 +6,7 @@ mocha                                 \
   test/validate_test.js               \
   test/queue/bucket_test.js           \
   test/queue/blobstore_test.js        \
+  test/queue/queueservice_test.js     \
   test/api/ping_test.js               \
   test/api/createtask_test.js         \
   test/api/minimumtask_test.js        \

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -21,4 +21,5 @@ mocha                                 \
   test/api/retry_test.js              \
   test/api/deadline_test.js           \
   test/api/expiretask_test.js         \
+  test/api/expirequeues_test.js       \
   ;


### PR DESCRIPTION
This address two bugs:
https://bugzilla.mozilla.org/show_bug.cgi?id=1170821
https://bugzilla.mozilla.org/show_bug.cgi?id=1162943

Once this is rolled out, we give it a week or a few days, and then remove all the legacy queues. So that pull URLs again returns an array of one queue.

For now we abuse the list returned for priority, to migrate underlying queue names to a new name without dropping tasks.