### PR TITLE
Fix extra exception messages after deadline

### DIFF
--- a/queue/deadlineresolver.js
+++ b/queue/deadlineresolver.js
@@ -186,7 +186,7 @@ class DeadlineResolver {
 
     // Publish messages about the last run if it was resolved here
     var run = _.last(task.runs);
-    if (run.reasonResolved  === 'deadline-exceeded' ||
+    if (run.reasonResolved  === 'deadline-exceeded' &&
         run.state           === 'exception') {
       debug("Resolved taskId: %s, by deadline", taskId);
       await this.publisher.taskException({


### PR DESCRIPTION
Avoid duplicate messages for exceptions after deadline... We should only report the messages if `deadline-exceeded` is the reason.

If it was cancelled, or something else... we should publish another message about that.

----
Note, this is not a violation of our promises... messages are at-least once, so delivering them an extra time a few hours later is technically okay (but not elegant). And in practice we consider it a bug.