### PR TITLE
Bug 1193607: update schema for limite scope charset

### DIFF
--- a/schemas/constants.js
+++ b/schemas/constants.js
@@ -84,4 +84,7 @@ module.exports = {
 
   // Slugid pattern, for when-ever that is useful
   "slugid-pattern":  "^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$",
+
+  // Pattern for scope names, for when-ever that is useful
+  "scope-pattern":   "^[\x20-\x7e]*",
 };

--- a/schemas/create-task-request.yml
+++ b/schemas/create-task-request.yml
@@ -106,8 +106,10 @@ properties:
         A scope (or scope-patterns) which the task is
         authorized to use. This can be a string or a string
         ending with `*` which will authorize all scopes for
-        which the string is a prefix.
+        which the string is a prefix.  Scopes must be composed of
+        printable ASCII characters and spaces.
       type:         string
+      pattern:      {$const: scope-pattern}
   payload:
     title:          "Task Payload"
     description: |

--- a/schemas/task.yml
+++ b/schemas/task.yml
@@ -101,8 +101,10 @@ properties:
         A scope (or scope-patterns) which the task is
         authorized to use. This can be a string or a string
         ending with `*` which will authorize all scopes for
-        which the string is a prefix.
-      type:         string
+        which the string is a prefix.  Scopes must be composed of
+        printable ASCII characters and spaces.
+      type:         string,
+      pattern:      {$const: scope-pattern}
   payload:
     title:          "Task Payload"
     description: |


### PR DESCRIPTION
I can make similar changes for all components -- but would it be better to define a scope (and scopelist, scopeset, etc.) in taskcluster-base, and refer to that schema from elsewhere?