### PR TITLE
Bug 1221132 - improve wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TaskCluster Queue [![Build Status](https://travis-ci.org/taskcluster/taskcluster-queue.png?branch=master)](https://travis-ci.org/taskcluster/taskcluster-queue)
 
-This the central queue coordinating execution of tasks in the TaskCluster setup.
+This is the central queue coordinating execution of tasks in the TaskCluster setup.
 
 Project Structure
 -----------------

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -259,7 +259,7 @@ api.declare({
     "routing-key: `<route>`, then when the AMQP message about the task is",
     "published, the message will be CC'ed with the routing-key: ",
     "`route.<route>`. This is useful if you want another component to listen",
-    "for completed tasks you have posted."
+    "for completed tasks you have posted.",
     "",
     "**Important** Any scopes the task requires are also required for creating",
     "the task. Please see the Request Payload (Task Definition) for details."

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -256,11 +256,13 @@ api.declare({
     "",
     "**Task specific routing-keys**, using the `task.routes` property you may",
     "define task specific routing-keys. If a task has a task specific ",
-    "routing-key: `<route>`, then the poster will be required to posses the",
-    "scope `queue:route:<route>`. And when the an AMQP message about the task",
-    "is published the message will be CC'ed with the routing-key: ",
+    "routing-key: `<route>`, then when the AMQP message about the task is",
+    "published, the message will be CC'ed with the routing-key: ",
     "`route.<route>`. This is useful if you want another component to listen",
     "for completed tasks you have posted."
+    "",
+    "**Important** Any scopes the task requires are also required for creating",
+    "the task. Please see the Request Payload (Task Definition) for details."
   ].join('\n')
 }, async function(req, res) {
   var taskId  = req.params.taskId;
@@ -384,7 +386,7 @@ api.declare({
 
 /** Define tasks */
 api.declare({
-  method:     'post',
+  method:     'put',
   route:      '/task/:taskId/define',
   name:       'defineTask',
   scopes:     [
@@ -407,6 +409,9 @@ api.declare({
     "and when the dependencies of a tasks have been resolved, you can schedule",
     "the task by calling `/task/:taskId/schedule`. This eliminates the need to",
     "store tasks somewhere else while waiting for dependencies to resolve.",
+    "",
+    "**Important** Any scopes the task requires are also required for defining",
+    "the task. Please see the Request Payload (Task Definition) for details.",
     "",
     "**Note** this operation is **idempotent**, as long as you upload the same",
     "task definition as previously defined this operation is safe to retry."

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -386,7 +386,7 @@ api.declare({
 
 /** Define tasks */
 api.declare({
-  method:     'put',
+  method:     'post',
   route:      '/task/:taskId/define',
   name:       'defineTask',
   scopes:     [

--- a/schemas/create-task-request.yml
+++ b/schemas/create-task-request.yml
@@ -26,9 +26,10 @@ properties:
     description: |
       Identifier for the scheduler that _defined_ this task, this can be an
       identifier for a user or a service like the `"task-graph-scheduler"`.
-      Along with the `taskGroupId` this is used to form the permission scope
-      `queue:assume:scheduler-id:<schedulerId>/<taskGroupId>`,
-      this scope is necessary to _schedule_ a defined task, or _rerun_ a task.
+      **Task submitter required scopes**
+      `queue:assume:scheduler-id:<schedulerId>/<taskGroupId>`.
+      This scope is also necessary to _schedule_ a defined task, or _rerun_ a
+      task.
     type:           string
     minLength:      {$const: identifier-min-length}
     maxLength:      {$const: identifier-max-length}
@@ -47,6 +48,8 @@ properties:
     title:          "Task Specific Routes"
     description: |
       List of task specific routes, AMQP messages will be CC'ed to these routes.
+      **Task submitter required scopes** `queue:route:<route>` for
+      each route given.
     type:           array
     default:        []
     items:
@@ -65,9 +68,10 @@ properties:
   priority:
     title:          "Task Priority"
     description: |
-      Priority of task, this defaults to `normal` and the scope
-      `queue:task-priority:high` is required to define a task with `priority`
-      set to `high`. Additional priority levels may be added later.
+      Priority of task, this defaults to `normal`. Additional levels may be
+      added later.
+      **Task submitter required scopes** `queue:task-priority:high` for high
+      priority tasks.
     enum:
       - high
       - normal
@@ -108,6 +112,9 @@ properties:
         ending with `*` which will authorize all scopes for
         which the string is a prefix.  Scopes must be composed of
         printable ASCII characters and spaces.
+        **Task submitter required scopes** The same scope-pattern(s) given
+        (otherwise a task could be submitted to perform an action that the
+        task submitter is not authorized to perform).
       type:         string
       pattern:      {$const: scope-pattern}
   payload:


### PR DESCRIPTION
The docs didn't consistently define which scopes are required by a task submitter due to entries in the task definition payload.

I'd like to introduce consistent wording so that it is simple to have an overview of which scopes you require for submitting any particular task definition.