### PR TITLE
Bug 1228012: Deprecate all assume: scopes in API endpoints

### DIFF
--- a/routes/artifacts.js
+++ b/routes/artifacts.js
@@ -18,7 +18,7 @@ api.declare({
       'assume:worker-id:<workerGroup>/<workerId>'
     ], [
       'queue:create-artifact:<name>',
-      'queue:claim-task:<taskId>/<runId>'
+      'queue:claim-run-id:<taskId>/<runId>'
     ]
   ],
   deferAuth:  true,

--- a/routes/artifacts.js
+++ b/routes/artifacts.js
@@ -17,8 +17,7 @@ api.declare({
       'queue:create-artifact:<name>',
       'assume:worker-id:<workerGroup>/<workerId>'
     ], [
-      'queue:create-artifact:<name>',
-      'queue:claim-run-id:<taskId>/<runId>'
+      'queue:create-artifact:<taskId>/<runId>'
     ]
   ],
   deferAuth:  true,

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -237,7 +237,16 @@ api.declare({
   route:      '/task/:taskId',
   name:       'createTask',
   idempotent: true,
-  scopes:     [['queue:create-task:<provisionerId>/<workerType>']],
+  scopes:     [
+    [
+      // Legacy scope option to be removed
+      'queue:create-task:<provisionerId>/<workerType>',
+    ], [
+      'queue:define-task:<provisionerId>/<workerType>',
+      'queue:task-group-id:<schedulerId>/<taskGroupId>',
+      'queue:schedule-task:<schedulerId>/<taskGroupId>',
+    ],
+  ],
   deferAuth:  true,
   input:      'create-task-request.json#',
   output:     'task-status-response.json#',
@@ -273,11 +282,19 @@ api.declare({
     return 'queue:route:' + route;
   });
 
+  // Patch default values and validate timestamps
+  var detail = patchAndValidateTaskDef(taskId, taskDef);
+  if (detail) {
+    return res.status(detail.code).json(detail.json);
+  }
+
   // Authenticate request by providing parameters, and then validate that the
   // requester satisfies all the scopes assigned to the task
   if (!req.satisfies({
     provisionerId:  taskDef.provisionerId,
-    workerType:     taskDef.workerType
+    workerType:     taskDef.workerType,
+    schedulerId:    taskDef.schedulerId,
+    taskGroupId:    taskDef.taskGroupId,
   }) || !req.satisfies([taskDef.scopes])
      || !req.satisfies([routeScopes])) {
     return;
@@ -287,12 +304,6 @@ api.declare({
   if (taskDef.priority !== 'normal' &&
       !req.satisfies([['queue:task-priority:' + taskDef.priority]])) {
     return;
-  }
-
-  // Patch default values and validate timestamps
-  var detail = patchAndValidateTaskDef(taskId, taskDef);
-  if (detail) {
-    return res.status(detail.code).json(detail.json);
   }
 
   // Insert entry in deadline queue
@@ -390,8 +401,14 @@ api.declare({
   route:      '/task/:taskId/define',
   name:       'defineTask',
   scopes:     [
+    // Legacy scopes
     ['queue:define-task:<provisionerId>/<workerType>'],
-    ['queue:create-task:<provisionerId>/<workerType>']
+    ['queue:create-task:<provisionerId>/<workerType>'],
+    [
+    // Future scope
+      'queue:define-task:<provisionerId>/<workerType>',
+      'queue:task-group-id:<schedulerId>/<taskGroupId>',
+    ]
   ],
   deferAuth:  true,
   input:      'create-task-request.json#',
@@ -425,11 +442,19 @@ api.declare({
     return 'queue:route:' + route;
   });
 
+  // Patch default values and validate timestamps
+  var detail = patchAndValidateTaskDef(taskId, taskDef);
+  if (detail) {
+    return res.status(detail.code).json(detail.json);
+  }
+
   // Authenticate request by providing parameters, and then validate that the
   // requester satisfies all the scopes assigned to the task
   if(!req.satisfies({
     provisionerId:  taskDef.provisionerId,
-    workerType:     taskDef.workerType
+    workerType:     taskDef.workerType,
+    schedulerId:    taskDef.schedulerId,
+    taskGroupId:    taskDef.taskGroupId,
   }) || !req.satisfies([taskDef.scopes])
      || !req.satisfies([routeScopes])) {
     return;
@@ -439,12 +464,6 @@ api.declare({
   if (taskDef.priority !== 'normal' &&
       !req.satisfies([['queue:task-priority:' + taskDef.priority]])) {
     return;
-  }
-
-  // Patch default values and validate timestamps
-  var detail = patchAndValidateTaskDef(taskId, taskDef);
-  if (detail) {
-    return res.status(detail.code).json(detail.json);
   }
 
   // Insert entry in deadline queue (garbage entries are acceptable)
@@ -526,8 +545,11 @@ api.declare({
   name:       'scheduleTask',
   scopes:     [
     [
+      // Legacy scope
       'queue:schedule-task',
       'assume:scheduler-id:<schedulerId>/<taskGroupId>'
+    ], [
+      'queue:schedule-task:<schedulerId>/<taskGroupId>',
     ]
   ],
   deferAuth:  true,
@@ -614,8 +636,11 @@ api.declare({
   name:       'rerunTask',
   scopes:     [
     [
+      // Legacy scopes
       'queue:rerun-task',
       'assume:scheduler-id:<schedulerId>/<taskGroupId>'
+    ], [
+      'queue:rerun-task:<schedulerId>/<taskGroupId>',
     ]
   ],
   deferAuth:  true,
@@ -731,8 +756,11 @@ api.declare({
   name:       'cancelTask',
   scopes:     [
     [
+      // Legacy scopes
       'queue:cancel-task',
       'assume:scheduler-id:<schedulerId>/<taskGroupId>'
+    ], [
+      'queue:cancel-task:<schedulerId>/<taskGroupId>',
     ]
   ],
   deferAuth:  true,
@@ -843,8 +871,11 @@ api.declare({
   name:       'pollTaskUrls',
   scopes: [
     [
+      // Legacy scopes
       'queue:poll-task-urls',
       'assume:worker-type:<provisionerId>/<workerType>'
+    ], [
+      'queue:poll-task-urls:<provisionerId>/<workerType>',
     ]
   ],
   deferAuth:  true,
@@ -888,9 +919,12 @@ api.declare({
   name:       'claimTask',
   scopes: [
     [
+      // Legacy
       'queue:claim-task',
       'assume:worker-type:<provisionerId>/<workerType>',
       'assume:worker-id:<workerGroup>/<workerId>'
+    ], [
+      'queue:claim-task:<provisionerId>/<workerType>'
     ]
   ],
   deferAuth:  true,
@@ -998,7 +1032,7 @@ api.declare({
     start:  new Date(Date.now() - 15 * 60 * 1000),
     expiry: new Date(takenUntil.getTime() + 15 * 60 * 1000),
     scopes: [
-      'queue:claim-task:' + taskId + '/' + runId
+      'queue:claim-run-id:' + taskId + '/' + runId
     ].concat(task.scopes),
     credentials: this.credentials
   });
@@ -1023,10 +1057,11 @@ api.declare({
   name:       'reclaimTask',
   scopes: [
     [
+      // Legacy
       'queue:claim-task',
       'assume:worker-id:<workerGroup>/<workerId>'
     ], [
-      'queue:claim-task:<taskId>/<runId>'
+      'queue:claim-run-id:<taskId>/<runId>'
     ]
   ],
   deferAuth:  true,
@@ -1122,7 +1157,7 @@ api.declare({
     start:  new Date(Date.now() - 15 * 60 * 1000),
     expiry: new Date(takenUntil.getTime() + 15 * 60 * 1000),
     scopes: [
-      'queue:claim-task:' + taskId + '/' + runId
+      'queue:claim-run-id:' + taskId + '/' + runId
     ].concat(task.scopes),
     credentials: this.credentials
   });
@@ -1236,10 +1271,11 @@ api.declare({
   name:       'reportCompleted',
   scopes: [
     [
+      // Legacy
       'queue:resolve-task',
       'assume:worker-id:<workerGroup>/<workerId>'
     ], [
-      'queue:claim-task:<taskId>/<runId>'
+      'queue:claim-run-id:<taskId>/<runId>'
     ]
   ],
   deferAuth:  true,
@@ -1267,10 +1303,11 @@ api.declare({
   name:       'reportFailed',
   scopes: [
     [
+      // Legacy
       'queue:resolve-task',
       'assume:worker-id:<workerGroup>/<workerId>'
     ], [
-      'queue:claim-task:<taskId>/<runId>'
+      'queue:claim-run-id:<taskId>/<runId>'
     ]
   ],
   deferAuth:  true,
@@ -1300,10 +1337,11 @@ api.declare({
   name:       'reportException',
   scopes: [
     [
+      // Legacy
       'queue:resolve-task',
       'assume:worker-id:<workerGroup>/<workerId>'
     ], [
-      'queue:claim-task:<taskId>/<runId>'
+      'queue:claim-run-id:<taskId>/<runId>'
     ]
   ],
   deferAuth:  true,

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -244,7 +244,7 @@ api.declare({
     ], [
       'queue:define-task:<provisionerId>/<workerType>',
       'queue:task-group-id:<schedulerId>/<taskGroupId>',
-      'queue:schedule-task:<schedulerId>/<taskGroupId>',
+      'queue:schedule-task:<schedulerId>/<taskGroupId>/<taskId>',
     ],
   ],
   deferAuth:  true,
@@ -291,6 +291,7 @@ api.declare({
   // Authenticate request by providing parameters, and then validate that the
   // requester satisfies all the scopes assigned to the task
   if (!req.satisfies({
+    taskId,
     provisionerId:  taskDef.provisionerId,
     workerType:     taskDef.workerType,
     schedulerId:    taskDef.schedulerId,
@@ -549,7 +550,7 @@ api.declare({
       'queue:schedule-task',
       'assume:scheduler-id:<schedulerId>/<taskGroupId>'
     ], [
-      'queue:schedule-task:<schedulerId>/<taskGroupId>',
+      'queue:schedule-task:<schedulerId>/<taskGroupId>/<taskId>',
     ]
   ],
   deferAuth:  true,
@@ -580,8 +581,9 @@ api.declare({
 
   // Authenticate request by providing parameters
   if(!req.satisfies({
+    taskId,
     schedulerId:    task.schedulerId,
-    taskGroupId:    task.taskGroupId
+    taskGroupId:    task.taskGroupId,
   })) {
     return;
   }
@@ -640,7 +642,7 @@ api.declare({
       'queue:rerun-task',
       'assume:scheduler-id:<schedulerId>/<taskGroupId>'
     ], [
-      'queue:rerun-task:<schedulerId>/<taskGroupId>',
+      'queue:rerun-task:<schedulerId>/<taskGroupId>/<taskId>',
     ]
   ],
   deferAuth:  true,
@@ -675,6 +677,7 @@ api.declare({
 
   // Authenticate request by providing parameters
   if(!req.satisfies({
+    taskId,
     schedulerId:    task.schedulerId,
     taskGroupId:    task.taskGroupId
   })) {
@@ -760,7 +763,7 @@ api.declare({
       'queue:cancel-task',
       'assume:scheduler-id:<schedulerId>/<taskGroupId>'
     ], [
-      'queue:cancel-task:<schedulerId>/<taskGroupId>',
+      'queue:cancel-task:<schedulerId>/<taskGroupId>/<taskId>',
     ]
   ],
   deferAuth:  true,
@@ -795,6 +798,7 @@ api.declare({
 
   // Authenticate request by providing parameters
   if(!req.satisfies({
+    taskId,
     schedulerId:    task.schedulerId,
     taskGroupId:    task.taskGroupId
   })) {
@@ -1032,7 +1036,9 @@ api.declare({
     start:  new Date(Date.now() - 15 * 60 * 1000),
     expiry: new Date(takenUntil.getTime() + 15 * 60 * 1000),
     scopes: [
-      'queue:claim-run-id:' + taskId + '/' + runId
+      'queue:reclaim-task:' + taskId + '/' + runId,
+      'queue:resolve-task:' + taskId + '/' + runId,
+      'queue:create-artifact:' + taskId + '/' + runId,
     ].concat(task.scopes),
     credentials: this.credentials
   });
@@ -1061,7 +1067,7 @@ api.declare({
       'queue:claim-task',
       'assume:worker-id:<workerGroup>/<workerId>'
     ], [
-      'queue:claim-run-id:<taskId>/<runId>'
+      'queue:reclaim-task:<taskId>/<runId>'
     ]
   ],
   deferAuth:  true,
@@ -1157,7 +1163,9 @@ api.declare({
     start:  new Date(Date.now() - 15 * 60 * 1000),
     expiry: new Date(takenUntil.getTime() + 15 * 60 * 1000),
     scopes: [
-      'queue:claim-run-id:' + taskId + '/' + runId
+      'queue:reclaim-task:' + taskId + '/' + runId,
+      'queue:resolve-task:' + taskId + '/' + runId,
+      'queue:create-artifact:' + taskId + '/' + runId,
     ].concat(task.scopes),
     credentials: this.credentials
   });
@@ -1275,7 +1283,7 @@ api.declare({
       'queue:resolve-task',
       'assume:worker-id:<workerGroup>/<workerId>'
     ], [
-      'queue:claim-run-id:<taskId>/<runId>'
+      'queue:resolve-task:<taskId>/<runId>'
     ]
   ],
   deferAuth:  true,
@@ -1307,7 +1315,7 @@ api.declare({
       'queue:resolve-task',
       'assume:worker-id:<workerGroup>/<workerId>'
     ], [
-      'queue:claim-run-id:<taskId>/<runId>'
+      'queue:resolve-task:<taskId>/<runId>'
     ]
   ],
   deferAuth:  true,
@@ -1341,7 +1349,7 @@ api.declare({
       'queue:resolve-task',
       'assume:worker-id:<workerGroup>/<workerId>'
     ], [
-      'queue:claim-run-id:<taskId>/<runId>'
+      'queue:resolve-task:<taskId>/<runId>'
     ]
   ],
   deferAuth:  true,

--- a/test/api/artifact_test.js
+++ b/test/api/artifact_test.js
@@ -291,7 +291,7 @@ suite('Post artifacts', function() {
     });
   });
 
-  test("Post S3 artifact (with bad scopes in task.scopes)", async () => {
+  test("Post S3 artifact (with creds from claimTask)", async () => {
     var taskId = slugid.v4();
     debug("### Creating task");
     let taskDef2 = _.defaults({
@@ -312,10 +312,6 @@ suite('Post artifacts', function() {
       storageType:  's3',
       expires:      taskcluster.fromNowJSON('1 day'),
       contentType:  'application/json'
-    }).then(() => {
-      assume().fail("Expected authentication error");
-    }, (err) => {
-      debug("Got expected authentication error: %s", err);
     });
   });
 


### PR DESCRIPTION
Got rid of all the `assume:` scopes...

Well, I left them in for keeping compatibility...

IMO, the big non-trivial thing we have to move here is:
`defineTask` and `createTask`, those are called by clients directly or through scheduler... We need those to move to the new scopes, and remove the legacy scopes.

Once that is done, the road is pretty open for API end-points to list tasks by `taskGroupId` and implementation of new big graph scheduler.