### PR TITLE
Trying to make superseded more generic

### DIFF
--- a/schemas/task-exception-request.yml
+++ b/schemas/task-exception-request.yml
@@ -39,11 +39,23 @@ properties:
       error from which it couldn't recover. The queue will not retry runs
       resolved with this reason, but you are clearly signaling that this is a
       bug in the worker code.
-      **Report `superseded`** if the task was determined to have been
-      superseded by another task, and its results are no longer needed.  It is
-      convention in this case to create an artifact entitled
-      `public/superseded-by` containing the taskId of the task that superseded
-      this one.
+      **Report `superseded`** if a task can be determined to have been
+      superseded by another task, meaning its results aren't of interest, the
+      worker may report the task as _superseded_. The exact semantics of this
+      feature is worker-specific, upon encountering you should consult the
+      worker-specific documentation. Workers are free to use this exception as
+      they see fit, but they **must** document the behavior. It's strongly
+      recommended that the worker uploads a JSON artifact titled
+      `public/superseded-by.json` with details of why the task was superseded,
+      and a `taskId` property pointing to the task that superseded it.
+      Example use-case: Consider a worker that computes the next prime greater
+      than some number N given in `task.payload`, and then stores this prime in
+      a global database. If upon claiming a task the worker does a lookup in
+      the database and observes that the next time for N is already computed,
+      then it may be useful to just report the task as `superseded`.
+      In other cases a worker could also provide a facility by which
+      task-specific could report the task as `superseded`, for example using a
+      special exit code (not recommended, just illustrative).
 additionalProperties:   false
 required:
   - reason


### PR DESCRIPTION
I propose this documentation instead as slightly more generic...

As I see it the queue cannot dictate the definition of `superseded` and workers must supply their own semantics for this.. Ie. they must define what artifacts it uploads... And what it means to resolve a task as superseded...

@djmitche, I'm still not super happy about this. We're making a super-special case that all task consumers now have to deal with in some way or another.

---

Crazy idea... maybe we have a method `reportSuperseded(taskId, runId, {taskId: <supersededByTaskId>, runId: <supersededByRunId>})`. Which would then transplant the superseded run (`<supersededByRunId>`) to the task... (obviously requiring that `<supersededByRunId>` is resolved).
Meaning that if `<supersededByRunId>` failed, then the run added is also failed, if `<supersededByRunId>` was completed then the run added is also completed. And we create alias artifacts for everything.

This would require us to add a `supersededBy: {taskId: ..., runId: ...}` to the representation of a run in the task status structure. This way consumers that wanted to see the task a superseded would still be able to see this. But general task consumers that might not care about superseded-logic would still be able to consume the task.
I think this falls very close to the proposal where we upload the same artifacts and set the same resolution as the task we was superseded by (and doing that would certainly be easier).

It seems wrong to have a task reported as superseded and then it can't be consumed by consumers who are unaware of the superseded feature. Because superseded just means a newer or more-relevant result have been produced in a separate task.

I'm tempted to accept this solution because we need the coalescence feature. But I seriously fear we're building a major footgun here. As all future consumers of tasks will have to deal with "what does superseded mean?". One isn't bad, but reason from task exception is already hard to use given that I added `internal-error` and `resources-unavailable` both of which I don't like :)
(granted it may just be me being crazy here, most task consumers should probably only care about task state completed/failed/exception, and not concern themselves with the `reason` for why the task was resolved as exception).
