### PR TITLE
Update to new errors

### DIFF
--- a/routes/v1.js
+++ b/routes/v1.js
@@ -807,9 +807,14 @@ api.declare({
 
   // Report 404, if task entity doesn't exist
   if (!task) {
-    return res.status(404).json({
-      message:  "Task not found"
-    });
+    return res.reportError(
+            "ResourceNotFound",
+            "Task not found",
+            [
+            "The given taskId does not correspond to a task that exists.",
+            "Are you sure this task has been submitted before?"
+            ].join('\n')
+    );
   }
 
   // Authenticate request by providing parameters

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -809,11 +809,11 @@ api.declare({
   if (!task) {
     return res.reportError(
             "ResourceNotFound",
-            "Task not found",
             [
-            "The given taskId does not correspond to a task that exists.",
+            "{{taskId}} does not correspond to a task that exists.",
             "Are you sure this task has been submitted before?"
-            ].join('\n')
+            ].join('\n'),
+            {taskId: taskId}
     );
   }
 

--- a/test/api/helper.js
+++ b/test/api/helper.js
@@ -8,6 +8,7 @@ var exchanges       = require('../../queue/exchanges');
 var taskcluster     = require('taskcluster-client');
 var mocha           = require('mocha');
 var load            = require('../../src/main');
+var debug           = require('debug')('test:api:helper');
 
 // Some default clients for the mockAuthServer
 var defaultClients = [
@@ -79,6 +80,7 @@ var webServer = null;
 // Setup before tests
 mocha.before(async () => {
   // Create mock authentication server
+  debug("### Creating mock authentication server")
   authServer = await base.testing.createMockAuthServer({
     port:     60407, // This is hardcoded into config/test.js
     clients:  defaultClients
@@ -87,6 +89,7 @@ mocha.before(async () => {
   webServer = await load('server', loadOptions);
 
   // Create client for working with API
+  debug("### Creating client")
   helper.baseUrl = 'http://localhost:' + webServer.address().port + '/v1';
   var reference = v1.reference({baseUrl: helper.baseUrl});
   helper.Queue = taskcluster.createClient(reference);

--- a/test/api/reruntask_test.js
+++ b/test/api/reruntask_test.js
@@ -31,7 +31,6 @@ suite('Rerun task', function() {
     }
   };
 
-
   test("create, claim, complete and rerun (is idempotent)", async () => {
     var taskId = slugid.v4();
 
@@ -89,7 +88,8 @@ suite('Rerun task', function() {
   });
 
   test("throw error on missing task", async () => {
-    helper.queue.rerunTask(0).catch( (err) => {
+    var taskId = slugid.v4();
+    await helper.queue.rerunTask(taskId).catch( (err) => {
         assert.equal(err.statusCode, 404);
     });
   });

--- a/test/api/reruntask_test.js
+++ b/test/api/reruntask_test.js
@@ -23,13 +23,14 @@ suite('Rerun task', function() {
     metadata: {
       name:           "Unit testing task",
       description:    "Task created during unit tests",
-      owner:          'jonsafj@mozilla.com',
+      owner:          'jonasfj@mozilla.com',
       source:         'https://github.com/taskcluster/taskcluster-queue'
     },
     tags: {
       purpose:        'taskcluster-testing'
     }
   };
+
 
   test("create, claim, complete and rerun (is idempotent)", async () => {
     var taskId = slugid.v4();
@@ -85,5 +86,11 @@ suite('Rerun task', function() {
 
     debug("### Requesting task rerun (again)");
     await helper.queue.rerunTask(taskId);
+  });
+
+  test("throw error on missing task", async () => {
+    helper.queue.rerunTask(0).catch( (err) => {
+        assert.equal(err.statusCode, 404);
+    });
   });
 });

--- a/test/api/reruntask_test.js
+++ b/test/api/reruntask_test.js
@@ -32,7 +32,7 @@ suite('Rerun task', function() {
   };
 
   test("create, claim, complete and rerun (is idempotent)", async () => {
-    var taskId = slugid.v4();
+    let taskId = slugid.v4();
 
     await Promise.all([
       helper.events.listenFor('pending', helper.queueEvents.taskPending({
@@ -88,9 +88,10 @@ suite('Rerun task', function() {
   });
 
   test("throw error on missing task", async () => {
-    var taskId = slugid.v4();
+    let taskId = slugid.v4();
     await helper.queue.rerunTask(taskId).catch( (err) => {
         assert.equal(err.statusCode, 404);
+        assert.equal(err.code, "ResourceNotFound");
     });
   });
 });


### PR DESCRIPTION
This replaces our first ```res.status()``` with the new ```res.reportError()```. More will follow if this works.