### PR TITLE
Employ continuationToken for listArtifact

### DIFF
--- a/routes/artifacts.js
+++ b/routes/artifacts.js
@@ -6,9 +6,6 @@ var Promise = require('promise');
 var base    = require('taskcluster-base');
 var urllib  = require('url');
 
-// Maximum number of artifacts to list
-const MAX_ARTIFACTS_LISTING = 10 * 1000;
-
 /** Post artifact */
 api.declare({
   method:     'post',
@@ -571,44 +568,45 @@ api.declare({
 api.declare({
   method:     'get',
   route:      '/task/:taskId/runs/:runId/artifacts',
+  query: {
+    continuationToken: /./,
+    limit: /^[0-9]+$/,
+  },
   name:       'listArtifacts',
   stability:  base.API.stability.experimental,
   output:     'list-artifacts-response.json#',
   title:      "Get Artifacts from Run",
   description: [
-    "Returns a list of artifacts and associated meta-data for a given run."
+    "Returns a list of artifacts and associated meta-data for a given run.",
+    "",
+    "As a task may have many artifacts paging may be necessary. If this",
+    "end-point returns a `continuationToken`, you should call the end-point",
+    "again with the `continuationToken` as the query-string option:",
+    "`continuationToken`.",
+    "",
+    "By default this end-point will list up-to 1000 artifacts in a single page",
+    "you may limit this with the query-string parameter `limit`.",
   ].join('\n')
 }, async function(req ,res) {
-  var taskId = req.params.taskId;
-  var runId  = parseInt(req.params.runId);
+  let taskId        = req.params.taskId;
+  let runId         = parseInt(req.params.runId);
+  let continuation  = req.query.continuationToken || null;
+  let limit         = parseInt(req.query.limit || 1000);
   // TODO: Add support querying using prefix
 
-  // Warning: this doesn't employ continuation token and may take a while if
-  // someone uploads more than MAX_ARTIFACTS_LISTING artifacts. We'll cut it
-  // short at MAX_ARTIFACTS_LISTING tasks and return an error
-  var artifacts = [];
-  await this.Artifact.query({
+  let artifacts = await this.Artifact.query({
     taskId: taskId,
-    runId:  runId
-  }, {
-    handler:    (artifact) => {
-      assert(artifacts.length <= MAX_ARTIFACTS_LISTING,
-             "Won't list more than MAX_ARTIFACTS_LISTING artifacts");
-      artifacts.push(artifact.json());
-    }
-  });
+    runId:  runId,
+  }, {continuation, limit});
 
-  // Refuse to list artifacts if there is more than MAX_ARTIFACTS_LISTING
-  if (artifacts.length > MAX_ARTIFACTS_LISTING) {
-    return res.status(412).json({
-      message:    "Won't list artifacts for task with " +
-                  MAX_ARTIFACTS_LISTING + " artifacts!"
-    });
+  let result = {
+    artifacts: artifacts.entries.map(artifact => artifact.json()),
+  };
+  if (artifacts.continuation) {
+    result.continuationToken = artifacts.continuation;
   }
 
-  return res.reply({
-    artifacts:      artifacts
-  });
+  return res.reply(result);
 });
 
 
@@ -617,61 +615,66 @@ api.declare({
   method:     'get',
   route:      '/task/:taskId/artifacts',
   name:       'listLatestArtifacts',
+  query: {
+    continuationToken: /./,
+    limit: /^[0-9]+$/,
+  },
   stability:  base.API.stability.experimental,
   output:     'list-artifacts-response.json#',
   title:      "Get Artifacts from Latest Run",
   description: [
     "Returns a list of artifacts and associated meta-data for the latest run",
-    "from the given task."
+    "from the given task.",
+    "",
+    "As a task may have many artifacts paging may be necessary. If this",
+    "end-point returns a `continuationToken`, you should call the end-point",
+    "again with the `continuationToken` as the query-string option:",
+    "`continuationToken`.",
+    "",
+    "By default this end-point will list up-to 1000 artifacts in a single page",
+    "you may limit this with the query-string parameter `limit`.",
   ].join('\n')
 }, async function(req ,res) {
-  var taskId = req.params.taskId;
+  let taskId        = req.params.taskId;
+  let continuation  = req.query.continuationToken || null;
+  let limit         = parseInt(req.query.limit || 1000);
   // TODO: Add support querying using prefix
 
   // Load task status structure from table
-  var task = await this.Task.load({taskId: taskId}, true);
+  let task = await this.Task.load({taskId: taskId}, true);
 
   // Give a 404 if not found
   if (!task) {
-    return res.status(404).json({
-      message:  "Task not found"
-    });
+    return res.reportError(
+      'ResourceNotFound',
+      "No task with taskId: {{taskId}} found",
+      {taskId}
+    );
   }
 
   // Check that we have runs
   if (task.runs.length === 0) {
-    return res.status(404).json({
-      message:  "Task doesn't have any runs"
-    });
+    return res.reportError(
+      'ResourceNotFound',
+      "Task with taskId: {{taskId}} does not have any runs",
+      {taskId}
+    );
   }
 
   // Find highest runId
-  var runId = task.runs.length - 1;
+  let runId = task.runs.length - 1;
 
-  // Warning: this doesn't employ continuation token and may take a while if
-  // someone uploads more than MAX_ARTIFACTS_LISTING artifacts. We'll cut it
-  // short at MAX_ARTIFACTS_LISTING tasks and return an error
-  var artifacts = [];
-  await this.Artifact.query({
+  let artifacts = await this.Artifact.query({
     taskId: taskId,
-    runId:  runId
-  }, {
-    handler:    (artifact) => {
-      assert(artifacts.length <= MAX_ARTIFACTS_LISTING,
-             "Won't list more than MAX_ARTIFACTS_LISTING artifacts");
-      artifacts.push(artifact.json());
-    }
-  });
+    runId:  runId,
+  }, {continuation, limit});
 
-  // Refuse to list artifacts if there is more than MAX_ARTIFACTS_LISTING
-  if (artifacts.length > MAX_ARTIFACTS_LISTING) {
-    return res.status(412).json({
-      message:    "Won't list artifacts for task with " +
-                  MAX_ARTIFACTS_LISTING + " artifacts!"
-    });
+  let result = {
+    artifacts: artifacts.entries.map(artifact => artifact.json()),
+  };
+  if (artifacts.continuation) {
+    result.continuationToken = artifacts.continuation;
   }
 
-  return res.reply({
-    artifacts:      artifacts
-  });
+  return res.reply(result);
 });

--- a/schemas/list-artifacts-response.yml
+++ b/schemas/list-artifacts-response.yml
@@ -52,6 +52,17 @@ properties:
         - name
         - expires
         - contentType
+  continuationToken:
+    type:             string
+    title:            "Continuation Token"
+    description: |
+      Opaque `continuationToken` to be given as query-string option to get the
+      next set of artifacts.
+      This property is only present if another request is necessary to fetch all
+      results. In practice the next request with a `continuationToken` may not
+      return additional results, but it can. Thus, you can only be sure to have
+      all the results if you've callwith `continuationToken` until you get a
+      result without a `continuationToken`.
 additionalProperties: false
 required:
   - artifacts

--- a/schemas/list-artifacts-response.yml
+++ b/schemas/list-artifacts-response.yml
@@ -61,7 +61,7 @@ properties:
       This property is only present if another request is necessary to fetch all
       results. In practice the next request with a `continuationToken` may not
       return additional results, but it can. Thus, you can only be sure to have
-      all the results if you've callwith `continuationToken` until you get a
+      all the results if you've called with `continuationToken` until you get a
       result without a `continuationToken`.
 additionalProperties: false
 required:

--- a/schemas/list-task-group-response.yml
+++ b/schemas/list-task-group-response.yml
@@ -25,13 +25,13 @@ properties:
     type:             string
     title:            "Continuation Token"
     description: |
-      Opaque `continuationToken` to be given as query-string option if all the
-      tasks in the task-group wasn't included in this result.
+      Opaque `continuationToken` to be given as query-string option to get the
+      next set of tasks in the task-group.
       This property is only present if another request is necessary to fetch all
       results. In practice the next request with a `continuationToken` may not
       return additional results, but it can. Thus, you can only be sure to have
       all the results if you've called `listTaskGroup` with `continuationToken`
-      until you got a result without a `continuationToken`.
+      until you get a result without a `continuationToken`.
 required:
  - taskGroupId
  - members

--- a/test/api/artifact_test.js
+++ b/test/api/artifact_test.js
@@ -764,6 +764,53 @@ suite('Artifacts', function() {
     assume(artifact.contentType).equals('application/json');
   });
 
+  test("listArtifacts (missing task)", async () => {
+    await helper.queue.listArtifacts(slugid.v4(), 0).then(
+      ()  => assert(false, "Expected error"),
+      err => assume(err.code).equals('ResourceNotFound'),
+    );
+  });
+
+  test("listLatestArtifacts (missing task)", async () => {
+    await helper.queue.listLatestArtifacts(slugid.v4(), 0).then(
+      ()  => assert(false, "Expected error"),
+      err => assume(err.code).equals('ResourceNotFound'),
+    );
+  });
+
+  test("listArtifacts, listLatestArtifacts (missing run)", async () => {
+    debug("### Creating task");
+    let taskId = slugid.v4();
+    await helper.queue.defineTask(taskId, taskDef);
+
+    debug("### listArtifacts (runId: 0, is missing)");
+    await helper.queue.listArtifacts(taskId, 0).then(
+      ()  => assert(false, "Expected error"),
+      err => assume(err.code).equals('ResourceNotFound'),
+    );
+
+    debug("### listLatestArtifacts (task has no runs)");
+    await helper.queue.listLatestArtifacts(taskId).then(
+      ()  => assert(false, "Expected error"),
+      err => assume(err.code).equals('ResourceNotFound'),
+    );
+
+    debug("### scheduleTask");
+    await helper.queue.scheduleTask(taskId);
+
+    debug("### listArtifacts (runId: 0, is present)");
+    await helper.queue.listArtifacts(taskId, 0);
+
+    debug("### listLatestArtifacts (works)");
+    await helper.queue.listLatestArtifacts(taskId);
+
+    debug("### listArtifacts (runId: 1, is missing)");
+    await helper.queue.listArtifacts(taskId, 1).then(
+      ()  => assert(false, "Expected error"),
+      err => assume(err.code).equals('ResourceNotFound'),
+    );
+  });
+
   test("listArtifacts, listLatestArtifacts (continuationToken)", async () => {
     debug("### Creating task");
     let taskId = slugid.v4();

--- a/test/api/artifact_test.js
+++ b/test/api/artifact_test.js
@@ -1,5 +1,5 @@
 suite('Artifacts', function() {
-  var debug         = require('debug')('test:api:claim');
+  var debug         = require('debug')('test:artifacts');
   var assert        = require('assert');
   var slugid        = require('slugid');
   var _             = require('lodash');
@@ -762,5 +762,78 @@ suite('Artifacts', function() {
 
     // Ensure content type was not updated
     assume(artifact.contentType).equals('application/json');
+  });
+
+  test("listArtifacts, listLatestArtifacts (continuationToken)", async () => {
+    debug("### Creating task");
+    let taskId = slugid.v4();
+    await helper.queue.createTask(taskId, taskDef);
+
+    debug("### Claiming task");
+    // First runId is always 0, so we should be able to claim it here
+    await helper.queue.claimTask(taskId, 0, {
+      workerGroup:    'my-worker-group',
+      workerId:       'my-worker'
+    });
+
+    debug("### Create two artifacts (don't upload anything to S3)");
+    await Promise.all([
+      helper.queue.createArtifact(taskId, 0, 'public/s3-A.json', {
+        storageType:  's3',
+        expires:      taskcluster.fromNowJSON('1 day'),
+        contentType:  'application/json'
+      }),
+      helper.queue.createArtifact(taskId, 0, 'public/s3-B.json', {
+        storageType:  's3',
+        expires:      taskcluster.fromNowJSON('1 day'),
+        contentType:  'application/json'
+      })
+    ]);
+
+    debug("### reportCompleted");
+    await helper.queue.reportCompleted(taskId, 0);
+
+    debug("### listArtifacts");
+    let r1 = await helper.queue.listArtifacts(taskId, 0);
+    assume(r1.artifacts.length).equals(2);
+    assume(r1.artifacts[0].contentType).equals('application/json');
+    assume(r1.artifacts[1].contentType).equals('application/json');
+
+    debug("### listArtifacts, limit = 1");
+    let r2 = await helper.queue.listArtifacts(taskId, 0, {limit: 1});
+    assume(r2.artifacts.length).equals(1);
+    assume(r2.artifacts[0].contentType).equals('application/json');
+    assert(r2.continuationToken, "missing continuationToken");
+
+    debug("### listArtifacts, w. continuationToken");
+    let r3 = await helper.queue.listArtifacts(taskId, 0, {
+      continuationToken: r2.continuationToken,
+    });
+    assume(r3.artifacts.length).equals(1);
+    assume(r3.artifacts[0].contentType).equals('application/json');
+    assert(!r3.continuationToken, "unexpected continuationToken");
+    assume(r3.artifacts[0].name).not.equals(r2.artifacts[0].name);
+
+
+    debug("### listLatestArtifacts");
+    let r4 = await helper.queue.listLatestArtifacts(taskId);
+    assume(r4.artifacts.length).equals(2);
+    assume(r4.artifacts[0].contentType).equals('application/json');
+    assume(r4.artifacts[1].contentType).equals('application/json');
+
+    debug("### listLatestArtifacts, limit = 1");
+    let r5 = await helper.queue.listLatestArtifacts(taskId, {limit: 1});
+    assume(r5.artifacts.length).equals(1);
+    assume(r5.artifacts[0].contentType).equals('application/json');
+    assert(r5.continuationToken, "missing continuationToken");
+
+    debug("### listLatestArtifacts, w. continuationToken");
+    let r6 = await helper.queue.listLatestArtifacts(taskId, {
+      continuationToken: r5.continuationToken,
+    });
+    assume(r6.artifacts.length).equals(1);
+    assume(r6.artifacts[0].contentType).equals('application/json');
+    assert(!r6.continuationToken, "unexpected continuationToken");
+    assume(r6.artifacts[0].name).not.equals(r5.artifacts[0].name);
   });
 });


### PR DESCRIPTION
I don't think this breaks anything....
Query string parameters are optional, so old client will just keep on working as they do now :)
Notice that I didn't have to modify the old tests, just add a new test case.

right now we list up to 10k without continuation token... After this we'll only be able to list up to 1k without continuation token... But with continuation token we'll be unbounded...

I doubt anyone has more than 1k artifacts anyways... So this should do fine :)