### PR TITLE
Must create tasks after their dependencies

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -539,6 +539,9 @@ api.declare({
     "for completed tasks you have posted.  The caller must have scope",
     "`queue:route:<route>` for each route.",
     "",
+    "**Dependencies**, any tasks referenced in `task.dependencies` must have",
+    "already been created at the time of this call.",
+    "",
     "**Important** Any scopes the task requires are also required for creating",
     "the task. Please see the Request Payload (Task Definition) for details."
   ].join('\n')


### PR DESCRIPTION
I'm basing this determination on checks made in the `dependencyTracker`.