### PR TITLE
Count poll-loop cycles

### DIFF
--- a/src/dependencyresolver.js
+++ b/src/dependencyresolver.js
@@ -85,6 +85,8 @@ class DependencyResolver extends events.EventEmitter {
   async _pollResolvedTasks() {
     while(!this._stopping) {
       let messages = await this.queueService.pollResolvedQueue();
+      this.monitor.count('resolved-queue-poll-requests', 1);
+      this.monitor.count('resolved-queue-polled-messages', messages.length);
       debug("Fetched %s messages", messages.length);
 
       await Promise.all(messages.map(async (m) => {


### PR DESCRIPTION
Now we can make an alert in signalfx.. if we check that the loop counter is always above > 0.

This is similar to what jhford is doing with deadmansswitch...