### PR TITLE
Count when work queues reach zero

### DIFF
--- a/src/claimresolver.js
+++ b/src/claimresolver.js
@@ -119,6 +119,10 @@ class ClaimResolver {
       }));
 
       if (messages.length === 0 && !this.stopping) {
+        // Count that the queue is empty, we should have this happen regularly.
+        // otherwise, we're not keeping up with the messages. We can setup
+        // alerts to notify us if this doesn't happen for say 40 min.
+        this.monitor.count('claim-queue-empty');
         await this.sleep(this.pollingDelay);
       }
     }
@@ -266,4 +270,3 @@ class ClaimResolver {
 
 // Export ClaimResolver
 module.exports = ClaimResolver;
-

--- a/src/deadlineresolver.js
+++ b/src/deadlineresolver.js
@@ -116,6 +116,10 @@ class DeadlineResolver {
       }));
 
       if (messages.length === 0 && !this.stopping) {
+        // Count that the queue is empty, we should have this happen regularly.
+        // otherwise, we're not keeping up with the messages. We can setup
+        // alerts to notify us if this doesn't happen for say 40 min.
+        this.monitor.count('deadline-queue-empty');
         await this.sleep(this.pollingDelay);
       }
     }
@@ -223,4 +227,3 @@ class DeadlineResolver {
 
 // Export DeadlineResolver
 module.exports = DeadlineResolver;
-

--- a/src/dependencyresolver.js
+++ b/src/dependencyresolver.js
@@ -105,6 +105,10 @@ class DependencyResolver {
       }));
 
       if (messages.length === 0 && !this._stopping) {
+        // Count that the queue is empty, we should have this happen regularly.
+        // otherwise, we're not keeping up with the messages. We can setup
+        // alerts to notify us if this doesn't happen for say 40 min.
+        this.monitor.count('resolved-queue-empty');
         await new Promise(accept => setTimeout(accept, this._pollingDelay));
       }
     }


### PR DESCRIPTION
Some stats to see if claimResolvers work queue reaches zero... If it doesn't that explains why @lundjordan saw a task in state `running` 14 hours after `takenUntil` expired.