### PR TITLE
bug 1285506 -- let queue rewrite urls for eu-central-1

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -128,10 +128,11 @@ production:
     taskGroupMemberTableName:     'QueueTaskGroupMembers'
     taskRequirementTableName:     'QueueTaskRequirement'
     taskDependencyTableName:      'QueueTaskDependency'
-    publicArtifactBucketProxies:
-      'us-east-1':  's3-copy-proxy-us-east-1.taskcluster.svc.tutum.io'
-      'us-west-1':  's3-copy-proxy-us-west-1.taskcluster.svc.tutum.io'
-    usePublicArtifactBucketProxy: !env:bool USE_PUBLIC_ARTIFACT_BUCKET_PROXY
+    cloudMirrorRegions:
+      - us-east-1
+      - us-west-1
+      - eu-central-1
+    useCloudMirror: !env:bool USE_PUBLIC_ARTIFACT_BUCKET_PROXY
   taskcluster:
     authBaseUrl:      https://auth.taskcluster.net/v1
   server:

--- a/src/api.js
+++ b/src/api.js
@@ -69,7 +69,6 @@ var RUN_ID_PATTERN      = /^[1-9]*[0-9]+$/;
  *   claimTimeout:   // Number of seconds before a claim expires
  *   queueService:   // Azure QueueService object from queueservice.js
  *   regionResolver: // Instance of EC2RegionResolver,
- *   publicProxies:  // Mapping from EC2 region to proxy host for publicBucket
  *   credentials:    // TaskCluster credentials for issuing temp creds on claim
  *   dependencyTracker: // Instance of DependencyTracker
  * }
@@ -116,7 +115,6 @@ var api = new base.API({
     'claimTimeout',       // Number of seconds before a claim expires
     'queueService',       // Azure QueueService object from queueservice.js
     'regionResolver',     // Instance of EC2RegionResolver,
-    'publicProxies',      // Mapping from EC2 region to host for publicBucket
     'credentials',        // TC credentials for issuing temp creds on claim
     'dependencyTracker',  // Instance of DependencyTracker
     'monitor',            // base.monitor instance

--- a/src/artifacts.js
+++ b/src/artifacts.js
@@ -333,11 +333,7 @@ api.declare({
 /** Reply to an artifact request using taskId, runId, name and context */
 var replyWithArtifact = async function(taskId, runId, name, req, res) {
   // Load artifact meta-data from table storage
-  let artifact = await this.Artifact.load({
-    taskId:     taskId,
-    runId:      runId,
-    name:       name
-  }, true);
+  let artifact = await this.Artifact.load({taskId, runId, name}, true);
 
   // Give a 404, if the artifact couldn't be loaded
   if (!artifact) {

--- a/src/artifacts.js
+++ b/src/artifacts.js
@@ -333,10 +333,11 @@ api.declare({
 /** Reply to an artifact request using taskId, runId, name and context */
 var replyWithArtifact = async function(taskId, runId, name, req, res) {
   // Load artifact meta-data from table storage
-  let [artifact, task] = await Promise.all([
-    this.Artifact.load({taskId, runId, name}, true),
-    this.Task.load({taskId}, true),
-  ]);
+  let artifact = await this.Artifact.load({
+    taskId:     taskId,
+    runId:      runId,
+    name:       name
+  }, true);
 
   // Give a 404, if the artifact couldn't be loaded
   if (!artifact) {

--- a/src/main.js
+++ b/src/main.js
@@ -217,8 +217,7 @@ let load = base.loader({
     requires: ['cfg'],
     setup: async ({cfg}) => {
       let regionResolver = new EC2RegionResolver(
-        cfg.app.usePublicArtifactBucketProxy ?
-        _.keys(cfg.app.publicArtifactBucketProxies) : []
+        cfg.app.useCloudMirror ? cfg.app.cloudMirrorRegions : []
       );
       await regionResolver.loadIpRanges();
       return regionResolver;
@@ -249,7 +248,6 @@ let load = base.loader({
         publicBucket:     ctx.publicArtifactBucket,
         privateBucket:    ctx.privateArtifactBucket,
         regionResolver:   ctx.regionResolver,
-        publicProxies:    ctx.cfg.app.publicArtifactBucketProxies,
         credentials:      ctx.cfg.taskcluster.credentials,
         cloudMirrorHost:  ctx.cfg.app.cloudMirrorHost,
         artifactRegion:   ctx.cfg.aws.region,


### PR DESCRIPTION
Since we're no longer considering the useCloudMirror flag in the task, let's not bother loading it any longer.  This removes some more s3-copy-proxy leftovers and cleans up the configs.  It also adds eu-central-1 to the list of regions that we rewrite urls for, since we now have this regions in cloud-mirror

@jonasfj, I don't have a full test environment for this, can you double check that it looks OK?