### PR TITLE
Description of task expiraiton has a missing word.

### DIFF
--- a/schemas/constants.yml
+++ b/schemas/constants.yml
@@ -57,7 +57,7 @@ expires:
   title:        Expiration
   description: |
     Task expiration, time at which task definition and
-    status is deleted. Notice that all artifacts for the
+    status is deleted. Notice that all artifacts for the task
     must have an expiration that is no later than this.
   type:         string
   format:       date-time

--- a/schemas/create-task-request.yml
+++ b/schemas/create-task-request.yml
@@ -121,7 +121,7 @@ properties:
     title:          "Expiration"
     description: |
       Task expiration, time at which task definition and status is deleted.
-      Notice that all artifacts for the must have an expiration that is no
+      Notice that all artifacts for the task must have an expiration that is no
       later than this. If this property isn't it will be set to `deadline`
       plus one year (this default may subject to change).
     type:           string

--- a/schemas/task.yml
+++ b/schemas/task.yml
@@ -111,7 +111,7 @@ properties:
     title:          "Expiration"
     description: |
       Task expiration, time at which task definition and status is deleted.
-      Notice that all artifacts for the must have an expiration that is no
+      Notice that all artifacts for the task must have an expiration that is no
       later than this. If this property isn't it will be set to `deadline`
       plus one year (this default may subject to change).
     type:           string


### PR DESCRIPTION
The description of task expiration looks like it's missing 'task' in the
sentence: "Notice that all artifacts for the must have an expiration that is no
later than this."