### PR TITLE
Add inverse test for task group resolved

### DIFF
--- a/src/exchanges.js
+++ b/src/exchanges.js
@@ -142,7 +142,7 @@ var buildTaskGroupRoutingKey = function(options) {
     }, {
       name:             'schedulerId',
       summary:          '`schedulerId` for the task-group this message concerns',
-      required:         false, // TODO: Make this required sometime after the deadlinequeue is drained (Aug 3, 2016)
+      required:         true,
       maxSize:          22,
     }, {
       name:             'reserved',

--- a/test/taskgroup_test.js
+++ b/test/taskgroup_test.js
@@ -84,8 +84,11 @@ suite('TaskGroup features', () => {
       workerGroup:    'my-worker-group',
       workerId:       'my-worker',
     });
-    await helper.queue.reportCompleted(taskIdB, 0);
+    // Allow any message to arrive, so we're resonably sure
+    // there isn't one on the wire
+    await new Promise(resolve => setTimeout(resolve, 250));
     shouldveResolved = true;
+    await helper.queue.reportCompleted(taskIdB, 0);
 
     let tgf = await taskGroupResolvedHandler;
     assume(tgf.payload.taskGroupId).equals(taskGroupId);

--- a/test/taskgroup_test.js
+++ b/test/taskgroup_test.js
@@ -42,6 +42,12 @@ suite('TaskGroup features', () => {
       taskGroupId: taskGroupId,
     }));
 
+    let shouldveResolved = false;
+    let taskGroupResolvedHandler = helper.events.waitFor('task-group-resolved').then(message => {
+      assert(shouldveResolved, 'Task group resolved too soon!');
+      return message;
+    });
+
     debug('### Creating taskA');
     var r1 = await helper.queue.createTask(taskIdA, _.defaults({
       taskGroupId,
@@ -79,8 +85,9 @@ suite('TaskGroup features', () => {
       workerId:       'my-worker',
     });
     await helper.queue.reportCompleted(taskIdB, 0);
+    shouldveResolved = true;
 
-    var tgf = await helper.events.waitFor('task-group-resolved');
+    let tgf = await taskGroupResolvedHandler;
     assume(tgf.payload.taskGroupId).equals(taskGroupId);
     assume(tgf.payload.schedulerId).equals('dummy-scheduler');
   });


### PR DESCRIPTION
Also make schedulerId mandatory for task-group-resolved messages while I'm in here.