### PR TITLE
add request-region endpoint to preview queue-region

### DIFF
--- a/src/artifacts.js
+++ b/src/artifacts.js
@@ -460,6 +460,20 @@ api.declare({
   return replyWithArtifact.call(this, taskId, runId, name, req, res);
 });
 
+/** Tell me which region the queue thinks that requester is in */
+api.declare({
+  method: 'get',
+  route: '/request-region',
+  name: 'get-request-region',
+  title: 'Determine region of request as the queue sees it',
+  description: [
+    'Determine the region from which the queue thinks the request',
+    'originates.  This is mainly used as a diagnositic tools',
+  ].join('\ '),
+}, async (req, res) => {
+  res.status(200).json(this.regionResolver.getRegion(req));
+});
+
 /** Get latest artifact from task */
 api.declare({
   method:     'get',


### PR DESCRIPTION
Basically, just add a diagnostic endpoint to see which region the queue thinks that a requester lives in, or not a region.  There are three linter errors here locally, but they are in a file that I didn't touch.  @jonasfj, if you think this is OK, can you deploy it?
