### PR TITLE
Always resolve canonical region

### DIFF
--- a/src/artifacts.js
+++ b/src/artifacts.js
@@ -354,6 +354,7 @@ var replyWithArtifact = async function(taskId, runId, name, req, res) {
 
     if (bucket === this.publicBucket.bucket) {
       if (!region) {
+        debug('artifact from CDN for ip: %s', req.headers['x-forwarded-for']);
         url = this.publicBucket.createGetUrl(prefix);
       } else if (this.artifactRegion === region) {
         url = this.publicBucket.createGetUrl(prefix, true);

--- a/src/main.js
+++ b/src/main.js
@@ -246,7 +246,7 @@ let load = base.loader({
     requires: ['cfg'],
     setup: async ({cfg}) => {
       let regionResolver = new EC2RegionResolver(
-        cfg.app.useCloudMirror ? cfg.app.cloudMirrorRegions : []
+        cfg.app.useCloudMirror ? [...cfg.app.cloudMirrorRegions, cfg.aws.region] : []
       );
       await regionResolver.loadIpRanges();
       return regionResolver;


### PR DESCRIPTION
Should be a partial fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1306040

Basically we need to resolve region for us-west-2, otherwise we never go here:
https://github.com/taskcluster/taskcluster-queue/blob/8e9a186726233904457dbac429074a5954a6fbd3/src/artifacts.js#L358-L359
