### PR TITLE
Added hintId to all pending azure queue messages

### DIFF
--- a/src/queueservice.js
+++ b/src/queueservice.js
@@ -9,6 +9,7 @@ var base        = require('taskcluster-base');
 var azure       = require('fast-azure-storage');
 var crypto      = require('crypto');
 var taskcluster = require('taskcluster-client');
+var slugid      = require('slugid');
 
 /** Timeout for azure queue requests */
 var AZURE_QUEUE_TIMEOUT     = 7 * 1000;
@@ -588,6 +589,7 @@ class QueueService {
     return this._putMessage(queueNames[task.priority], {
       taskId:     task.taskId,
       runId:      runId,
+      hintId:     slugid.v4(),
     }, {
       ttl:          timeToDeadline,
       visibility:   0,


### PR DESCRIPTION
Once this is deployed we can modify the claimWork logic to ensure that we record the hintId for each claim...
Notably we can use this ensure that two different azure messages doesn't lead to the same task being claimed twice by the same worker (when there is a duplication of azure messages)...

Note: this could break workers if they won't ignore extra properties...
@petemoore ^ do you know if additional properties will break generic-worker, I doubt it.. but it would be hard to back out...