### PR TITLE
add schema docs

### DIFF
--- a/docs/task-schema.md
+++ b/docs/task-schema.md
@@ -1,0 +1,15 @@
+---
+layout:       default
+class:        html
+docson:       true
+marked:       true
+ejs:          true
+superagent:   true
+docref:       true
+---
+
+# Task Definition
+
+The following is the JSON schema for a task definition:
+
+<div data-render-schema='http://schemas.taskcluster.net/queue/v1/create-task-request.json'></div>


### PR DESCRIPTION
This isn't optimal.  Before https://github.com/taskcluster/taskcluster-docs/pull/142/commits/ea7386919b925e1f39f2a3cdbdf8d76043d12bc4, there was an extra API reference page like this one showing just the task schema.  tc-lib-docs doesn't provide a way to include such a thing.  So we'll put it under docs.

I'm not sure this will actually work, but we'll find out.