### PR TITLE
(not ready for merging) Make task schema support arbitrary links

### DIFF
--- a/schemas/task.yml
+++ b/schemas/task.yml
@@ -176,6 +176,31 @@ properties:
         type:           string
         format:         uri
         maxLength:      4096
+      links:
+        title:          "Links"
+        description: |
+          List of arbitrary links associated with the task. You could use this
+          for any purpose, one example might be a pointer back to a ci visualization
+          tool.
+        type:           array
+        items:
+          type:       object
+          title:      "Link pairs"
+          description: List of title/value link pairs
+          properties:
+            name:
+              description: Human readable description of where link goes
+              type:        string
+              maxLength:   255
+            url:
+              description: URL of link
+              type:        string
+              format:      uri
+              maxLength:   4096
+          required:
+            - name
+            - url
+          additionalProperties: false
     additionalProperties: false
     required:
       - name

--- a/test/createtask_test.js
+++ b/test/createtask_test.js
@@ -32,6 +32,8 @@ suite('Create task', function() {
       description:    'Task created during unit tests',
       owner:          'jonsafj@mozilla.com',
       source:         'https://github.com/taskcluster/taskcluster-queue',
+      links:          [{'link1': 'https://test.com/1/'},
+                       {'link2': 'https://test.com/2/'}],
     },
     tags: {
       purpose:        'taskcluster-testing',


### PR DESCRIPTION
This will be useful for https://bugzilla.mozilla.org/show_bug.cgi?id=1204490