### PR TITLE
Limit task.routes to 10

### DIFF
--- a/schemas/create-task-request.yml
+++ b/schemas/create-task-request.yml
@@ -91,7 +91,7 @@ properties:
       type:         string
       maxLength:    249
       minLength:    1
-    maxItems:       64
+    maxItems:       10 # 4kb frame limit, 10 * 255 = 2550 that leaves a few bytes for other fields
     uniqueItems:    true
   priority:
     title:          "Task Priority"


### PR DESCRIPTION
This is only on the create task request, not on the response since that would break what we currently have stored in the queue.