### PR TITLE
bug 1318648 - support instance instantiation in us-east-2

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -135,6 +135,7 @@ production:
     taskDependencyTableName:      'QueueTaskDependency'
     cloudMirrorRegions:
       - us-east-1
+      - us-east-2
       - us-west-1
       - eu-central-1
     useCloudMirror: !env:bool USE_PUBLIC_ARTIFACT_BUCKET_PROXY


### PR DESCRIPTION
in anticipation of increased load for g2.2xlarge (gecko-t-win7-32-gpu, gecko-t-win10-64-gpu worker types) enable instance instantiation in us-east-2 to mitigate cost and availability issues