### PR TITLE
Change azure tables auth mechanism

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-- '7'
+- '7.4.0'
 addons:
   apt:
     sources:

--- a/config.yml
+++ b/config.yml
@@ -100,10 +100,13 @@ defaults:
     forceSSL:         !env:flag FORCE_SSL
     trustProxy:       false
 
-  # Azure credentials (for table, blob and queue storage)
+  # Azure credentials (for blob and queue storage)
   azure:
     accountName:              !env AZURE_ACCOUNT_NAME
     accountKey:               !env AZURE_ACCOUNT_KEY
+
+  # Azure account (for table storage which uses auth for access)
+  azureTableAccount:          !env AZURE_TABLE_ACCOUNT_NAME
 
   pulse:
     username:                 !env PULSE_USERNAME
@@ -159,13 +162,6 @@ test:
     artifactContainer:            'artifacts'
     queuePrefix:                  'hacks'
     queuePrefix2:                 'hacks2' # For testing deletion of queues
-    taskTableName:                'TestTasks2'
-    artifactTableName:            'TestArtifacts2'
-    taskGroupTableName:           'TestTaskGroups2'
-    taskGroupMemberTableName:     'TestTaskGroupMembers2'
-    taskGroupActiveSetTableName:  'TestTaskSizeMembers2'
-    taskRequirementTableName:     'TestTaskRequirement2'
-    taskDependencyTableName:      'TestTaskDependency2'
     claimQueue:                   'test-claim-queue'
     deadlineQueue:                'test-deadline-queue'
     deadlineDelay:                1000
@@ -195,6 +191,7 @@ test:
     publicUrl:        http://localhost:60401
     port:             60401
     env:              development
+  azureTableAccount:  inMemory
 load-test:
   app:
     publishMetaData:              false

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "assume": "^1.2.4",
     "aws-sdk": "^2.1.21",
     "aws-sdk-promise": "0.0.2",
-    "azure-entities": "^1.0.2",
+    "azure-entities": "1.4.1",
     "azure-storage": "0.4.3",
     "babel-compile": "^2.0.0",
     "babel-preset-taskcluster": "^3.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -131,7 +131,7 @@ let load = loader({
     setup: async (ctx) => {
       let Artifact = data.Artifact.setup({
         table:            ctx.cfg.app.artifactTableName,
-        credentials:      ctx.cfg.azure,
+        account:          ctx.cfg.azureTableAccount,
         context: {
           blobStore:      ctx.artifactStore,
           publicBucket:   ctx.publicArtifactBucket,
@@ -151,7 +151,7 @@ let load = loader({
     setup: async ({cfg, monitor, process}) => {
       let Task = data.Task.setup({
         table:            cfg.app.taskTableName,
-        credentials:      cfg.azure,
+        account:          cfg.azureTableAccount,
         monitor:          monitor.prefix('table.tasks'),
       });
       await Task.ensureTable();
@@ -165,7 +165,7 @@ let load = loader({
     setup: async ({cfg, monitor, process}) => {
       let TaskGroup = data.TaskGroup.setup({
         table:            cfg.app.taskGroupTableName,
-        credentials:      cfg.azure,
+        account:          cfg.azureTableAccount,
         monitor:          monitor.prefix('table.taskgroups'),
       });
       await TaskGroup.ensureTable();
@@ -179,7 +179,7 @@ let load = loader({
     setup: async ({cfg, monitor, process}) => {
       let TaskGroupMember = data.TaskGroupMember.setup({
         table:            cfg.app.taskGroupMemberTableName,
-        credentials:      cfg.azure,
+        account:          cfg.azureTableAccount,
         monitor:          monitor.prefix('table.taskgroupmembers'),
       });
       await TaskGroupMember.ensureTable();
@@ -193,7 +193,7 @@ let load = loader({
     setup: async ({cfg, monitor, process}) => {
       let TaskGroupActiveSet = data.TaskGroupMember.setup({
         table:            cfg.app.taskGroupActiveSetTableName,
-        credentials:      cfg.azure,
+        account:          cfg.azureTableAccount,
         monitor:          monitor.prefix('table.taskgroupactivesets'),
       });
       await TaskGroupActiveSet.ensureTable();
@@ -207,7 +207,7 @@ let load = loader({
     setup: async ({cfg, monitor, process}) => {
       let TaskRequirement = data.TaskRequirement.setup({
         table:            cfg.app.taskRequirementTableName,
-        credentials:      cfg.azure,
+        account:          cfg.azureTableAccount,
         monitor:          monitor.prefix('table.taskrequirements'),
       });
       await TaskRequirement.ensureTable();
@@ -221,7 +221,7 @@ let load = loader({
     setup: async ({cfg, monitor, process}) => {
       let TaskDependency = data.TaskDependency.setup({
         table:            cfg.app.taskDependencyTableName,
-        credentials:      cfg.azure,
+        account:          cfg.azureTableAccount,
         monitor:          monitor.prefix('table.taskdependencies'),
       });
       await TaskDependency.ensureTable();

--- a/yarn.lock
+++ b/yarn.lock
@@ -201,15 +201,15 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-azure-entities@^1.0.2:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/azure-entities/-/azure-entities-1.2.1.tgz#86f4fd6e253ba63f6386a888716f783c9d6a6147"
+azure-entities@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/azure-entities/-/azure-entities-1.4.1.tgz#66a6156ac0779d47b54676bbb4d06953731004c3"
   dependencies:
     ajv "^4.11.2"
     babel-runtime "^6.22.0"
     buffertools "^2.1.3"
     debug "^2.2.0"
-    fast-azure-storage "^0.3.7"
+    fast-azure-storage "^1.0.2"
     json-stable-stringify "^1.0.0"
     lodash "^4.17.4"
     promise "^7.0.4"
@@ -1437,9 +1437,19 @@ extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
 
-fast-azure-storage@^0.3.0, fast-azure-storage@^0.3.7:
+fast-azure-storage@^0.3.0:
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/fast-azure-storage/-/fast-azure-storage-0.3.7.tgz#638b11ab074d5774cfd6fe8c628f0a419ef2874d"
+  dependencies:
+    debug "^2.2.0"
+    pixl-xml "^1.0.10"
+    promise "^7.0.4"
+  optionalDependencies:
+    libxmljs "^0.18.0"
+
+fast-azure-storage@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fast-azure-storage/-/fast-azure-storage-1.0.2.tgz#00d46a790f69d69bd3ea131ee95b5df7c5ac0e3b"
   dependencies:
     debug "^2.2.0"
     pixl-xml "^1.0.10"


### PR DESCRIPTION
As we discussed in irc. Auth already manages the production tc-queue azure tablestore account, so we should be safe to deploy there once I add this env var to tc-queue config. I expect these tests will fail right now because of the nodejs.org issue, but I'll rerun them tomorrow and then we can think about landing this.