### PR TITLE
Set clientId for claimed-task temporary creds

### DIFF
--- a/src/workclaimer.js
+++ b/src/workclaimer.js
@@ -277,7 +277,18 @@ class WorkClaimer extends events.EventEmitter {
     }, task.routes);
 
     // Create temporary credentials for the task
+    let clientId = [
+      'task-client',
+      taskId,
+      '${runId}',
+      'on',
+      workerGroup,
+      workerId,
+      'until'
+      '${takenUntil.getTime() / 1000}',
+    ].join('/');
     let credentials = taskcluster.createTemporaryCredentials({
+      clientId,
       start:  new Date(Date.now() - 15 * 60 * 1000),
       expiry: new Date(takenUntil.getTime() + 15 * 60 * 1000),
       scopes: [


### PR DESCRIPTION
This should set the clientId to something like `task-client/HpkPAF3GTkSfA9oxHSHIKQ/0/on/us-west-1/i-09ba01b87daecb599/at/1492905600`.  The `at` part is there so we can debug workers using expired credentials.  I wouldn't mind leaving that off, it just means we'll create a lot of creds with the same clientId.