### PR TITLE
Fix artifacts for runs that have been cancelled

### DIFF
--- a/src/artifacts.js
+++ b/src/artifacts.js
@@ -127,6 +127,14 @@ api.declare({
   var workerGroup = run.workerGroup;
   var workerId    = run.workerId;
 
+  // It is possible for these to be null if the task was
+  // cancelled or otherwise never claimed
+  if (!workerGroup || !workerId) {
+    return res.reportError('InputError',
+      'Run was not claimed by a worker and so no artifacts can exist',
+      {});
+  }
+
   // Authenticate request by providing parameters
   if (!req.satisfies({
     taskId,


### PR DESCRIPTION
https://sentry.prod.mozaws.net/operations/taskcluster-queue/issues/608950/

Not sure this is the correct fix, but it does handle the case this failed for. It was trying to access `workerGroup` and `workerId` for run 2 of the following:

```
{
  "status": {
    "taskId": "9phwiB_TSG2oMcD1Kkjbqg",
    "provisionerId": "buildbot-bridge",
    "workerType": "buildbot-bridge",
    "schedulerId": "task-graph-scheduler",
    "taskGroupId": "lkJdznr3QDyZdELDnQnwGA",
    "deadline": "2017-05-29T22:38:06.113Z",
    "expires": "3017-05-25T22:38:06.187Z",
    "retriesLeft": 5,
    "state": "exception",
    "runs": [
      {
        "runId": 0,
        "state": "failed",
        "reasonCreated": "scheduled",
        "reasonResolved": "failed",
        "workerGroup": "buildbot-bridge",
        "workerId": "buildbot-bridge",
        "takenUntil": "2017-05-25T23:10:03.219Z",
        "scheduled": "2017-05-25T22:38:56.335Z",
        "started": "2017-05-25T22:50:03.298Z",
        "resolved": "2017-05-25T22:50:13.162Z"
      },
      {
        "runId": 1,
        "state": "failed",
        "reasonCreated": "rerun",
        "reasonResolved": "failed",
        "workerGroup": "buildbot-bridge",
        "workerId": "buildbot-bridge",
        "takenUntil": "2017-05-25T23:10:51.470Z",
        "scheduled": "2017-05-25T22:50:13.760Z",
        "started": "2017-05-25T22:50:51.609Z",
        "resolved": "2017-05-25T22:51:25.571Z"
      },
      {
        "runId": 2,
        "state": "exception",
        "reasonCreated": "rerun",
        "reasonResolved": "canceled",
        "scheduled": "2017-05-25T22:51:26.166Z",
        "resolved": "2017-05-25T22:51:31.828Z"
      }
    ]
  },
  "artifact": {
    "storageType": "s3",
    "name": "public/properties.json",
    "expires": "3017-05-25T22:38:06.187Z",
    "contentType": "application/json"
  },
  "runId": 2,
  "version": 1
}

```