### PR TITLE
Revert "Limit task.routes to 10"

### DIFF
--- a/schemas/create-task-request.yml
+++ b/schemas/create-task-request.yml
@@ -91,7 +91,7 @@ properties:
       type:         string
       maxLength:    249
       minLength:    1
-    maxItems:       10 # 4kb frame limit, 10 * 255 = 2550 that leaves a few bytes for other fields
+    maxItems:       64
     uniqueItems:    true
   priority:
     title:          "Task Priority"


### PR DESCRIPTION
Reverts taskcluster/taskcluster-queue#151

At request of @escapewindow temporarily reverted limit of routes to 10.