### PR TITLE
Bug 1401206 - Extend the list of workers endpoint

### DIFF
--- a/schemas/list-workers-response.yml
+++ b/schemas/list-workers-response.yml
@@ -26,6 +26,26 @@ properties:
                     minLength:    {$const: identifier-min-length}
                     maxLength:    {$const: identifier-max-length}
                     pattern:      {$const: identifier-pattern}
+          disabled:
+                    title:        "Worker Disabled"
+                    description: |
+                      Disabling a worker allows the machine to remain alive but not accept jobs.
+                      Enabling a worker on the other hand will resume accepting jobs.
+                    type:         "boolean"
+          firstClaim:
+                    title:        "First task claimed"
+                    description: |
+                      Date of the first time this worker claimed a task.
+                    type:         string
+                    format:       date-time
+          latestTask:
+              title:          "Most Recent Claimed Task Identifier"
+              description: |
+                Unique task identifier, this is UUID encoded as
+                [URL-safe base64](http://tools.ietf.org/html/rfc4648#section-5) and
+                stripped of `=` padding.
+              type:           string
+              pattern:        {$const: slugid-pattern}
       additionalProperties: false
   continuationToken:
     type:           string

--- a/src/api.js
+++ b/src/api.js
@@ -2338,6 +2338,9 @@ api.declare({
       return {
         workerGroup: worker.workerGroup,
         workerId: worker.workerId,
+        firstClaim: worker.firstClaim.toJSON(),
+        latestTask: worker.recentTasks.pop(),
+        disabled: worker.disabled,
       };
     }),
   };

--- a/test/workerinfo_test.js
+++ b/test/workerinfo_test.js
@@ -170,6 +170,8 @@ suite('provisioners and worker-types', () => {
     const workerType = 'gecko-b-2-linux';
     const workerGroup = 'my-worker-group';
     const workerId = 'my-worker';
+    const taskId = slugid.v4();
+    const taskId2 = slugid.v4();
     const worker = {
       provisionerId,
       workerType,
@@ -181,6 +183,9 @@ suite('provisioners and worker-types', () => {
       firstClaim: new Date(),
     };
 
+    worker.recentTasks.push(taskId);
+    worker.recentTasks.push(taskId2);
+
     await Worker.create(worker);
 
     const result = await helper.queue.listWorkers(provisionerId, workerType);
@@ -188,6 +193,11 @@ suite('provisioners and worker-types', () => {
     assert(result.workers.length === 1, 'expected workers');
     assert(result.workers[0].workerGroup === worker.workerGroup, `expected ${worker.workerGroup}`);
     assert(result.workers[0].workerId === worker.workerId, `expected ${worker.workerId}`);
+    assert(result.workers[0].disabled === worker.disabled, `expected ${worker.disabled}`);
+    assert(result.workers[0].latestTask === taskId2, `expected ${taskId2}`);
+    assert(
+      new Date(result.workers[0].firstClaim).getTime() === worker.firstClaim.getTime(), `expected ${worker.firstClaim}`
+    );
   });
 
   test('list workers (limit and continuationToken)', async () => {


### PR DESCRIPTION
This PR is currently blocked by https://github.com/taskcluster/azure-entities/pull/30. Once that is merged, I will need to update azure-entities version. 