### PR TITLE
Bug 1401961 - Extend listWorkers endpoint to allow filtering by disabled workers

### DIFF
--- a/test/workerinfo_test.js
+++ b/test/workerinfo_test.js
@@ -200,6 +200,33 @@ suite('provisioners and worker-types', () => {
     );
   });
 
+  test('queue.listWorkers returns filtered workers', async () => {
+    const Worker = await helper.load('Worker', helper.loadOptions);
+    const provisionerId = 'prov1';
+    const workerType = 'gecko-b-2-linux';
+    const workerGroup = 'my-worker-group';
+    const workerId = 'my-worker';
+
+    const worker = {
+      provisionerId,
+      workerType,
+      workerGroup,
+      workerId,
+      recentTasks: Entity.types.SlugIdArray.create(),
+      expires: new Date('3017-07-29'),
+      disabled: false,
+      firstClaim: new Date(),
+    };
+
+    await Worker.create(worker);
+
+    const result = await helper.queue.listWorkers(provisionerId, workerType, {disabled: false});
+    const result2 = await helper.queue.listWorkers(provisionerId, workerType, {disabled: true});
+
+    assert(result.workers.length === 1, 'expected 1 worker');
+    assert(result2.workers.length === 0, 'expected no worker');
+  });
+
   test('list workers (limit and continuationToken)', async () => {
     const Worker = await helper.load('Worker', helper.loadOptions);
     const expires = new Date('3017-07-29');


### PR DESCRIPTION
For the page listing workers, one would want to filter results. Since we are dealing with a possibly long list, it's hard to filter when you have a paginated list. To solve this issue, we should return a filtered list instead. This pull-request adds `disabled` to the list of options.