### PR TITLE
Bug 1404010 - Extend the worker to have the runId of its most recentTask

### DIFF
--- a/schemas/list-workers-response.yml
+++ b/schemas/list-workers-response.yml
@@ -39,13 +39,26 @@ properties:
                     type:         string
                     format:       date-time
           latestTask:
-              title:          "Most Recent Claimed Task Identifier"
+              title:          "Most Recent Task"
               description: |
-                Unique task identifier, this is UUID encoded as
-                [URL-safe base64](http://tools.ietf.org/html/rfc4648#section-5) and
-                stripped of `=` padding.
-              type:           string
-              pattern:        {$const: slugid-pattern}
+                The most recent claimed task
+              type:       object
+              properties:
+                taskId:
+                  title:            "Task Identifier"
+                  description: |
+                    Unique task identifier, this is UUID encoded as
+                    [URL-safe base64](http://tools.ietf.org/html/rfc4648#section-5) and
+                    stripped of `=` padding.
+                  type:             string
+                  pattern:          {$const: slugid-pattern}
+                runId:
+                  title:            "Run Identifier"
+                  description: |
+                    Id of this task run, `run-id`s always starts from `0`
+                  type:             integer
+                  minimum:          {$const: min-run-id}
+                  maximum:          {$const: max-run-id}
       additionalProperties: false
   continuationToken:
     type:           string

--- a/schemas/worker-response.yml
+++ b/schemas/worker-response.yml
@@ -39,16 +39,26 @@ properties:
   recentTasks:
     title:        "Recent Tasks"
     description: |
-      20 most recent task Ids claimed by the worker.
+      List of 20 most recent tasks claimed by the worker.
     type:         array
     items:
-      title:      "Task Identifiers"
-      type:       string
-      description: |
-        Unique task identifier, this is UUID encoded as
-        [URL-safe base64](http://tools.ietf.org/html/rfc4648#section-5) and
-        stripped of `=` padding.
-      pattern:        {$const: slugid-pattern}
+      type:       object
+      properties:
+        taskId:
+          title:            "Task Identifier"
+          description: |
+            Unique task identifier, this is UUID encoded as
+            [URL-safe base64](http://tools.ietf.org/html/rfc4648#section-5) and
+            stripped of `=` padding.
+          type:             string
+          pattern:          {$const: slugid-pattern}
+        runId:
+          title:            "Run Identifier"
+          description: |
+            Id of this task run, `run-id`s always starts from `0`
+          type:             integer
+          minimum:          {$const: min-run-id}
+          maximum:          {$const: max-run-id}
   expires:
     title:        "Worker Expiration"
     description: |

--- a/src/api.js
+++ b/src/api.js
@@ -2478,7 +2478,7 @@ api.declare({
       workerType,
       workerGroup,
       workerId,
-      recentTasks: Entity.types.SlugIdArray.create(),
+      recentTasks: [],
       expires: expires || taskcluster.fromNow('1 day'),
       disabled: false,
       firstClaim: new Date(),

--- a/src/data.js
+++ b/src/data.js
@@ -912,9 +912,7 @@ let Worker = Entity.configure({
     firstClaim:       Entity.types.Date,
   },
   migrate(item) {
-    item.firstClaim = new Date(2000, 0, 1);
     item.recentTasks = [];
-    item.disabled = false;
 
     return item;
   },

--- a/src/data.js
+++ b/src/data.js
@@ -892,6 +892,32 @@ let Worker = Entity.configure({
 
     return item;
   },
+}).configure({
+  version:            4,
+  properties: {
+    provisionerId:    Entity.types.String,
+    workerType:       Entity.types.String,
+    workerGroup:      Entity.types.String,
+    workerId:         Entity.types.String,
+    /**
+     * List of objects with properties:
+     * - taskId
+     * - runId
+     * See JSON schema for documentation.
+     */
+    recentTasks:      Entity.types.JSON,
+    disabled:         Entity.types.Boolean,
+    // the time at which this worker should no longer be displayed
+    expires:          Entity.types.Date,
+    firstClaim:       Entity.types.Date,
+  },
+  migrate(item) {
+    item.firstClaim = new Date(2000, 0, 1);
+    item.recentTasks = [];
+    item.disabled = false;
+
+    return item;
+  },
 });
 
 /**
@@ -920,7 +946,7 @@ Worker.prototype.json = function() {
     workerId:         this.workerId,
     workerGroup:      this.workerGroup,
     disabled:         this.disabled,
-    recentTasks:      this.recentTasks.toArray(),
+    recentTasks:      this.recentTasks,
     expires:          this.expires.toJSON(),
     firstClaim:       this.firstClaim.toJSON(),
   };

--- a/src/workerinfo.js
+++ b/src/workerinfo.js
@@ -182,23 +182,11 @@ class WorkerInfo {
       return;
     }
 
-    const recentTasks = [...worker.recentTasks];
-
-    tasks.forEach((task) => {
-      const {taskId, runs} = task.status;
-      const runId = runs.length - 1;
-
-      if (!_.some(recentTasks, {taskId, runId})) {
-        recentTasks.push({taskId, runId});
-      }
-
-      if (recentTasks.length > RECENT_TASKS_LIMIT) {
-        recentTasks.shift();
-      }
-    });
-
-    await worker.modify(entity => {
-      entity.recentTasks = recentTasks;
+    await worker.modify(worker => {
+      worker.recentTasks = [
+        ...worker.recentTasks,
+        ...tasks.map(({status}) => ({taskId: status.taskId, runId: status.runs.length - 1})),
+      ].slice(-RECENT_TASKS_LIMIT);
     });
   }
 }

--- a/src/workerinfo.js
+++ b/src/workerinfo.js
@@ -2,6 +2,7 @@ const taskcluster = require('taskcluster-client');
 const Entity      = require('azure-entities');
 const assert      = require('assert');
 const slugid      = require('slugid');
+const _           = require('lodash');
 const debug       = require('debug')('workerinfo');
 
 const DAY = 24 * 60 * 60 * 1000;
@@ -136,15 +137,13 @@ class WorkerInfo {
           }
         }
 
-        const recentTasks = Entity.types.SlugIdArray.create();
-
         createEntry(this.Worker, {
           provisionerId,
           workerType,
           workerGroup,
           workerId,
           expires,
-          recentTasks,
+          recentTasks: [],
           disabled: false,
           firstClaim: new Date(),
         });
@@ -183,13 +182,14 @@ class WorkerInfo {
       return;
     }
 
-    const recentTasks = worker.recentTasks.clone();
+    const recentTasks = [...worker.recentTasks];
 
-    tasks.forEach((task, index) => {
-      const taskId = tasks[index].status.taskId;
+    tasks.forEach((task) => {
+      const {taskId, runs} = task.status;
+      const runId = runs.length;
 
-      if (recentTasks.indexOf(taskId) === -1) {
-        recentTasks.push(taskId);
+      if (!_.some(recentTasks, {taskId, runId})) {
+        recentTasks.push({taskId, runId});
       }
 
       if (recentTasks.length > RECENT_TASKS_LIMIT) {

--- a/src/workerinfo.js
+++ b/src/workerinfo.js
@@ -186,7 +186,7 @@ class WorkerInfo {
 
     tasks.forEach((task) => {
       const {taskId, runs} = task.status;
-      const runId = runs.length;
+      const runId = runs.length - 1;
 
       if (!_.some(recentTasks, {taskId, runId})) {
         recentTasks.push({taskId, runId});

--- a/test/workerinfo_test.js
+++ b/test/workerinfo_test.js
@@ -539,7 +539,7 @@ suite('provisioners and worker-types', () => {
     assert(result.workerGroup === worker.workerGroup, `expected ${worker.workerGroup}`);
     assert(result.workerId === worker.workerId, `expected ${worker.workerId}`);
     assert(result.recentTasks[0].taskId === taskId, `expected ${taskId}`);
-    assert(result.recentTasks[0].runId === 0, 'expected 1');
+    assert(result.recentTasks[0].runId === 0, 'expected 0');
     assert(new Date(result.expires).getTime() === updateProps.expires.getTime(), `expected ${updateProps.expires}`);
   });
 

--- a/test/workerinfo_test.js
+++ b/test/workerinfo_test.js
@@ -183,8 +183,8 @@ suite('provisioners and worker-types', () => {
       firstClaim: new Date(),
     };
 
-    worker.recentTasks.push({taskId, runId: 1});
-    worker.recentTasks.push({taskId: taskId2, runId: 1});
+    worker.recentTasks.push({taskId, runId: 0});
+    worker.recentTasks.push({taskId: taskId2, runId: 0});
 
     await Worker.create(worker);
 
@@ -474,9 +474,9 @@ suite('provisioners and worker-types', () => {
     const taskId2 = slugid.v4();
     const recentTasks = [];
 
+    recentTasks.push({taskId, runId: 0});
     recentTasks.push({taskId, runId: 1});
-    recentTasks.push({taskId, runId: 2});
-    recentTasks.push({taskId: taskId2, runId: 1});
+    recentTasks.push({taskId: taskId2, runId: 0});
 
     const worker = {
       provisionerId,
@@ -499,11 +499,11 @@ suite('provisioners and worker-types', () => {
     assert(new Date(result.expires).getTime() === worker.expires.getTime(), `expected ${worker.expires}`);
     assert(new Date(result.firstClaim).getTime() === worker.firstClaim.getTime(), `expected ${worker.firstClaim}`);
     assert(result.recentTasks[0].taskId === taskId, `expected ${taskId}`);
-    assert(result.recentTasks[0].runId === 1, 'expected 1');
+    assert(result.recentTasks[0].runId === 0, 'expected 0');
     assert(result.recentTasks[1].taskId === taskId, `expected ${taskId}`);
-    assert(result.recentTasks[1].runId === 2, 'expected 2');
+    assert(result.recentTasks[1].runId === 1, 'expected 1');
     assert(result.recentTasks[2].taskId === taskId2, `expected ${taskId2}`);
-    assert(result.recentTasks[2].runId === 1, 'expected 1');
+    assert(result.recentTasks[2].runId === 0, 'expected 0');
 
   });
 
@@ -516,7 +516,7 @@ suite('provisioners and worker-types', () => {
       workerType: 'gecko-b-2-linux',
       workerGroup: 'my-worker-group',
       workerId: 'my-worker',
-      recentTasks: [{taskId, runId: 1}],
+      recentTasks: [{taskId, runId: 0}],
       expires: new Date('3017-07-29'),
       disabled: false,
       firstClaim: new Date(),
@@ -539,7 +539,7 @@ suite('provisioners and worker-types', () => {
     assert(result.workerGroup === worker.workerGroup, `expected ${worker.workerGroup}`);
     assert(result.workerId === worker.workerId, `expected ${worker.workerId}`);
     assert(result.recentTasks[0].taskId === taskId, `expected ${taskId}`);
-    assert(result.recentTasks[0].runId === 1, 'expected 1');
+    assert(result.recentTasks[0].runId === 0, 'expected 1');
     assert(new Date(result.expires).getTime() === updateProps.expires.getTime(), `expected ${updateProps.expires}`);
   });
 
@@ -575,7 +575,7 @@ suite('provisioners and worker-types', () => {
     const result = await Worker.load({provisionerId, workerType, workerGroup, workerId});
 
     assert(result.recentTasks[0].taskId === taskId, `expected taskId ${taskId}`);
-    assert(result.recentTasks[0].runId === 1, 'expected runId 1');
+    assert(result.recentTasks[0].runId === 0, 'expected runId 0');
   });
 
   test('queue.getWorker returns 20 most recent taskIds', async () => {

--- a/test/workerinfo_test.js
+++ b/test/workerinfo_test.js
@@ -177,14 +177,14 @@ suite('provisioners and worker-types', () => {
       workerType,
       workerGroup,
       workerId,
-      recentTasks: Entity.types.SlugIdArray.create(),
+      recentTasks: [],
       expires: new Date('3017-07-29'),
       disabled: false,
       firstClaim: new Date(),
     };
 
-    worker.recentTasks.push(taskId);
-    worker.recentTasks.push(taskId2);
+    worker.recentTasks.push({taskId, runId: 1});
+    worker.recentTasks.push({taskId: taskId2, runId: 1});
 
     await Worker.create(worker);
 
@@ -194,7 +194,7 @@ suite('provisioners and worker-types', () => {
     assert(result.workers[0].workerGroup === worker.workerGroup, `expected ${worker.workerGroup}`);
     assert(result.workers[0].workerId === worker.workerId, `expected ${worker.workerId}`);
     assert(result.workers[0].disabled === worker.disabled, `expected ${worker.disabled}`);
-    assert(result.workers[0].latestTask === taskId2, `expected ${taskId2}`);
+    assert(result.workers[0].latestTask.taskId === taskId2, `expected ${taskId2}`);
     assert(
       new Date(result.workers[0].firstClaim).getTime() === worker.firstClaim.getTime(), `expected ${worker.firstClaim}`
     );
@@ -212,7 +212,7 @@ suite('provisioners and worker-types', () => {
       workerType,
       workerGroup,
       workerId,
-      recentTasks: Entity.types.SlugIdArray.create(),
+      recentTasks: [],
       expires: new Date('3017-07-29'),
       disabled: false,
       firstClaim: new Date(),
@@ -238,7 +238,7 @@ suite('provisioners and worker-types', () => {
       workerType,
       workerGroup,
       workerId: 'my-worker1',
-      recentTasks: Entity.types.SlugIdArray.create(),
+      recentTasks: [],
       expires,
       disabled: false,
       firstClaim: new Date(),
@@ -287,7 +287,7 @@ suite('provisioners and worker-types', () => {
       provisionerId, workerType,
       workerGroup: 'my-worker-group',
       workerId: 'my-worker',
-      recentTasks: Entity.types.SlugIdArray.create(),
+      recentTasks: [],
       expires: new Date('1017-07-29'),
       disabled: false,
       firstClaim: new Date(),
@@ -472,10 +472,11 @@ suite('provisioners and worker-types', () => {
     const workerId = 'my-worker';
     const taskId = slugid.v4();
     const taskId2 = slugid.v4();
-    const recentTasks = Entity.types.SlugIdArray.create();
+    const recentTasks = [];
 
-    recentTasks.push(taskId);
-    recentTasks.push(taskId2);
+    recentTasks.push({taskId, runId: 1});
+    recentTasks.push({taskId, runId: 2});
+    recentTasks.push({taskId: taskId2, runId: 1});
 
     const worker = {
       provisionerId,
@@ -489,7 +490,6 @@ suite('provisioners and worker-types', () => {
     };
 
     await Worker.create(worker);
-
     const result = await helper.queue.getWorker(provisionerId, workerType, workerGroup, workerId);
 
     assert(result.provisionerId === worker.provisionerId, `expected ${worker.provisionerId}`);
@@ -498,23 +498,25 @@ suite('provisioners and worker-types', () => {
     assert(result.workerId === worker.workerId, `expected ${worker.workerId}`);
     assert(new Date(result.expires).getTime() === worker.expires.getTime(), `expected ${worker.expires}`);
     assert(new Date(result.firstClaim).getTime() === worker.firstClaim.getTime(), `expected ${worker.firstClaim}`);
-    assert(result.recentTasks[0] === taskId, `expected ${taskId}`);
-    assert(result.recentTasks[1] === taskId2, `expected ${taskId2}`);
+    assert(result.recentTasks[0].taskId === taskId, `expected ${taskId}`);
+    assert(result.recentTasks[0].runId === 1, 'expected 1');
+    assert(result.recentTasks[1].taskId === taskId, `expected ${taskId}`);
+    assert(result.recentTasks[1].runId === 2, 'expected 2');
+    assert(result.recentTasks[2].taskId === taskId2, `expected ${taskId2}`);
+    assert(result.recentTasks[2].runId === 1, 'expected 1');
+
   });
 
   test('queue.declareWorker updates a worker', async () => {
     const Worker = await helper.load('Worker', helper.loadOptions);
-    const recentTasks = Entity.types.SlugIdArray.create();
     const taskId = slugid.v4();
-
-    recentTasks.push(taskId);
 
     const worker = await Worker.create({
       provisionerId: 'prov1',
       workerType: 'gecko-b-2-linux',
       workerGroup: 'my-worker-group',
       workerId: 'my-worker',
-      recentTasks,
+      recentTasks: [{taskId, runId: 1}],
       expires: new Date('3017-07-29'),
       disabled: false,
       firstClaim: new Date(),
@@ -536,7 +538,8 @@ suite('provisioners and worker-types', () => {
     assert(result.workerType === worker.workerType, `expected ${worker.workerType}`);
     assert(result.workerGroup === worker.workerGroup, `expected ${worker.workerGroup}`);
     assert(result.workerId === worker.workerId, `expected ${worker.workerId}`);
-    assert(result.recentTasks[0] === taskId, `expected ${taskId}`);
+    assert(result.recentTasks[0].taskId === taskId, `expected ${taskId}`);
+    assert(result.recentTasks[0].runId === 1, 'expected 1');
     assert(new Date(result.expires).getTime() === updateProps.expires.getTime(), `expected ${updateProps.expires}`);
   });
 
@@ -571,7 +574,8 @@ suite('provisioners and worker-types', () => {
 
     const result = await Worker.load({provisionerId, workerType, workerGroup, workerId});
 
-    assert(result.recentTasks.toArray()[0] === taskId, `expected taskId ${taskId}`);
+    assert(result.recentTasks[0].taskId === taskId, `expected taskId ${taskId}`);
+    assert(result.recentTasks[0].runId === 1, 'expected runId 1');
   });
 
   test('queue.getWorker returns 20 most recent taskIds', async () => {
@@ -613,7 +617,7 @@ suite('provisioners and worker-types', () => {
     assert(result.recentTasks.length === 20, 'expected to have 20 tasks');
 
     for (let i =0; i < 20; i++) {
-      assert(recentTasks[i] === taskIds[i + 10], `expected taskId ${taskIds[i + 10]}`);
+      assert(recentTasks[i].taskId === taskIds[i + 10], `expected taskId ${taskIds[i + 10]}`);
     }
   });
 
@@ -625,7 +629,6 @@ suite('provisioners and worker-types', () => {
     const workerId = 'my-worker';
     const taskId = slugid.v4();
     const taskId2 = slugid.v4();
-    const recentTasks = Entity.types.SlugIdArray.create();
     let result;
 
     const worker = {
@@ -633,7 +636,7 @@ suite('provisioners and worker-types', () => {
       workerType,
       workerGroup,
       workerId,
-      recentTasks,
+      recentTasks: [],
       expires: new Date('3017-07-29'),
       disabled: false,
       firstClaim: new Date(),


### PR DESCRIPTION
Use `Entity.types.JSON` with `[{taskId, runId}, ...]` instead of `Entity.types.SlugIdArray`.