### PR TITLE
Fix a typo in schema

### DIFF
--- a/schemas/post-artifact-response.yml
+++ b/schemas/post-artifact-response.yml
@@ -47,7 +47,7 @@ oneOf:
               type: object
               # Add something to ensure that all values are strings!
     additionalProperties: false
-    requiredProperties:
+    required:
       - requests
       - storageType
       - expires


### PR DESCRIPTION
This is important because it's making implementing taskcluster-lib-artifact-go harder