### PR TITLE
Add blob storageType to the list artifact response

### DIFF
--- a/schemas/list-artifacts-response.yml
+++ b/schemas/list-artifacts-response.yml
@@ -22,6 +22,7 @@ properties:
             the artifact.
           type:         string
           enum:
+            - blob
             - s3
             - azure
             - reference


### PR DESCRIPTION
Turns out this schema was missed.  Causes issues in the tools site