### PR TITLE
Fix declareWorker scope

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -2463,7 +2463,7 @@ api.declare({
   stability:  API.stability.experimental,
   scopes:     [
     [
-      'queue:declare-worker:<provisionerId>/<workerType>/<workerGroup><workerId>#<property>',
+      'queue:declare-worker:<provisionerId>/<workerType>/<workerGroup>/<workerId>#<property>',
     ],
   ],
   deferAuth:  true,


### PR DESCRIPTION
I assume this was a typo in the initial implementation...

@helfi92, if this is used by any workers we might have re-issue the scope...
But I don't see anything here: https://tools.taskcluster.net/auth/scopes
so we can probably just deploy...