### PR TITLE
Correctly send all headers as strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "netmask": "^1.0.5",
     "promise": "^7.0.4",
     "pulse-publisher": "^1.3.1",
-    "remotely-signed-s3": "^2.0.0",
+    "remotely-signed-s3": "^3.0.0",
     "request-ip": "^1.1.4",
     "slugid": "^1.1.0",
     "source-map-support": "^0.4.0",

--- a/schemas/post-artifact-response.yml
+++ b/schemas/post-artifact-response.yml
@@ -45,7 +45,9 @@ oneOf:
             headers:
               description: Headers of request
               type: object
-              # Add something to ensure that all values are strings!
+              additionalProperties:
+                type:
+                  string
     additionalProperties: false
     required:
       - requests

--- a/yarn.lock
+++ b/yarn.lock
@@ -2741,9 +2741,9 @@ regjsparser@^0.1.4:
   dependencies:
     jsesc "~0.5.0"
 
-remotely-signed-s3@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/remotely-signed-s3/-/remotely-signed-s3-2.0.0.tgz#37a202a55974299f5f77aab0d0430ceb755298a7"
+remotely-signed-s3@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/remotely-signed-s3/-/remotely-signed-s3-3.0.0.tgz#e02ac2e9c742089522eba92167d23c998a62d140"
   dependencies:
     aws4 "^1.6.0"
     babel-runtime "^6.23.0"


### PR DESCRIPTION
This is a subtle bug that's only caught in a statically, strongly typed language.  Basically, the header properties of single part uploads is a mapping of strings to strings, but for multi part is a mapping of strings to json-typed data (e.g. a number is a number, not converted to string).

Not having this makes the go lib-artifact library a lot more difficult to implement.

The difference between 3.0.0 and 2.0.0 of remotely signed s3 is pretty trivial: https://github.com/taskcluster/remotely-signed-s3/commit/1d7cfe3db4e2129cc7d5659d117818dbedda6e79

If you're OK with this change, I think it's a small enough change that it shouldn't effect the change freeze because it's a minor additive change that only touches code which a) doesn't crash the queue if it fails and b) only touches blob artifacts which aren't used by any fx57 automation.  Any errors in this code are limited to 500ISE for blob storage endpoints.