### PR TITLE
Modify action explanations to reflect path parameters

### DIFF
--- a/schemas/constants.yml
+++ b/schemas/constants.yml
@@ -132,25 +132,33 @@ dependency-relation:
 
 # Description of actions. They are defined on the provisioner
 action-description: |
-  Actions are defined on the provisioner. When an action is triggered,
-  it will use the `url` and `context` property to construct the URL and
-  perform a `POST` request. Note that the request will be signed with the
-  user's Taskcluster credentials.
+  Actions are defined on the provisioner and they are performed via a `POST` request using the `url`.
+  Depending on the `context`, the `url` will be able to fill path parameters. In addition, `context` is
+  used by the front-end to know where to display the action. For example, `context=worker`
+  will display the action on the worker explorer.
+
+  _Note: The request will be signed with the user's Taskcluster credentials._
 
 # Description of the action context
 action-context-description: |
   Actions have a "context" that is one of provisioner, worker-type,
-  or worker, indicating which it applies to. `context` is used to construct
-  the query string of the `POST` request.
-  If `context='worker'`, the query string will be
-  `?provisionerId=${PROVISIONER_ID}&workerType=${WORKER_TYPE}&workerGroup=${WORKER_GROUP}&workerId=${WORKER_ID}`.
-  If `context='worker-type'`, the query string will be
-  `?provisionerId=${PROVISIONER_ID}&workerType=${WORKER_TYPE}`.
-  If `context='provisioner'`, the query string will be
-  `?provisionerId=${PROVISIONER_ID}`.
+  or worker, indicating which it applies to. `context` is used by the front-end to know where to display the action.
+
+  | `context`   | Path parameters                                      | Page displayed        |
+  |-------------|------------------------------------------------------|-----------------------|
+  | provisioner | :provisionerId                                       | Worker explorer       |
+  | worker-type | :provisionerId, :workerType                          | Workers explorer      |
+  | worker      | :provisionerId, :workerType, :workerGroup, :workerId | Worker types explorer |
 
 # Description of the url property in an action.
 action-url-description: |
-  When an action is triggered, the `url`
-  and `context` property are used to make the `POST` request.
-  The request needs to be signed with the user's Taskcluster credentials.
+  When an action is triggered, a `POST` request is made using the `url`.
+  Depending on the `context`, the `url` will be able to fill the following path parameters:
+
+  | `context`   | Path parameters                                      |
+  |-------------|------------------------------------------------------|
+  | provisioner | :provisionerId                                       |
+  | worker-type | :provisionerId, :workerType                          |
+  | worker      | :provisionerId, :workerType, :workerGroup, :workerId |
+
+  _Note: The request needs to be signed with the user's Taskcluster credentials._

--- a/schemas/constants.yml
+++ b/schemas/constants.yml
@@ -133,7 +133,7 @@ dependency-relation:
 # Description of actions. They are defined on the provisioner
 action-description: |
   Actions are defined on the provisioner and they are performed via a `POST` request using the `url`.
-  Depending on the `context`, the `url` will be able to fill path parameters. In addition, `context` is
+  Depending on the `context`, the `url` will be filled with parameters. In addition, `context` is
   used by the front-end to know where to display the action. For example, `context=worker`
   will display the action on the worker explorer.
 
@@ -144,16 +144,16 @@ action-context-description: |
   Actions have a "context" that is one of provisioner, worker-type,
   or worker, indicating which it applies to. `context` is used by the front-end to know where to display the action.
 
-  | `context`   | Path parameters                                      | Page displayed        |
-  |-------------|------------------------------------------------------|-----------------------|
-  | provisioner | :provisionerId                                       | Worker explorer       |
-  | worker-type | :provisionerId, :workerType                          | Workers explorer      |
-  | worker      | :provisionerId, :workerType, :workerGroup, :workerId | Worker types explorer |
+  | `context`   | Page displayed        |
+  |-------------|-----------------------|
+  | provisioner | Worker Types Explorer |
+  | worker-type | Workers Explorer      |
+  | worker      | Worker Explorer       |
 
 # Description of the url property in an action.
 action-url-description: |
   When an action is triggered, a `POST` request is made using the `url`.
-  Depending on the `context`, the `url` will be able to fill the following path parameters:
+  Depending on the `context`, the following parameters will be substituted in the url:
 
   | `context`   | Path parameters                                      |
   |-------------|------------------------------------------------------|

--- a/schemas/constants.yml
+++ b/schemas/constants.yml
@@ -132,7 +132,7 @@ dependency-relation:
 
 # Description of actions. They are defined on the provisioner
 action-description: |
-  Actions are defined on the provisioner and they are performed via a `POST` request using the `url`.
+  Actions are defined on the provisioner and they are performed via a request using the `url` and `method`.
   Depending on the `context`, the `url` will be filled with parameters. In addition, `context` is
   used by the front-end to know where to display the action. For example, `context=worker`
   will display the action on the worker explorer.
@@ -146,13 +146,13 @@ action-context-description: |
 
   | `context`   | Page displayed        |
   |-------------|-----------------------|
-  | provisioner | Worker Types Explorer |
+  | provisioner | Provisioner Explorer  |
   | worker-type | Workers Explorer      |
   | worker      | Worker Explorer       |
 
 # Description of the url property in an action.
 action-url-description: |
-  When an action is triggered, a `POST` request is made using the `url`.
+  When an action is triggered, a request is made using the `url` and `method`.
   Depending on the `context`, the following parameters will be substituted in the url:
 
   | `context`   | Path parameters                                          |

--- a/schemas/constants.yml
+++ b/schemas/constants.yml
@@ -155,10 +155,10 @@ action-url-description: |
   When an action is triggered, a `POST` request is made using the `url`.
   Depending on the `context`, the following parameters will be substituted in the url:
 
-  | `context`   | Path parameters                                      |
-  |-------------|------------------------------------------------------|
-  | provisioner | :provisionerId                                       |
-  | worker-type | :provisionerId, :workerType                          |
-  | worker      | :provisionerId, :workerType, :workerGroup, :workerId |
+  | `context`   | Path parameters                                          |
+  |-------------|----------------------------------------------------------|
+  | provisioner | <provisionerId>                                          |
+  | worker-type | <provisionerId>, <workerType>                            |
+  | worker      | <provisionerId>, <workerType>, <workerGroup>, <workerId> |
 
   _Note: The request needs to be signed with the user's Taskcluster credentials._

--- a/schemas/list-provisioners-response.yml
+++ b/schemas/list-provisioners-response.yml
@@ -71,7 +71,7 @@ properties:
                 description: |
                   Method to indicate the desired action to be performed for a given resource.
                 type:   string
-                enum:   ["GET", "POST", "PUT", "DELETE", "PATCH"]
+                enum:   ["POST", "PUT", "DELETE", "PATCH"]
               description:
                 title:  "Description"
                 description: |

--- a/schemas/list-provisioners-response.yml
+++ b/schemas/list-provisioners-response.yml
@@ -66,7 +66,12 @@ properties:
                 title:  "URL"
                 description: {$const: action-url-description}
                 type:   string
-                format: uri
+              method:
+                title:  "Method"
+                description: |
+                  Method to indicate the desired action to be performed for a given resource.
+                type:   string
+                enum:   ["GET", "POST", "PUT", "DELETE", "PATCH"]
               description:
                 title:  "Description"
                 description: |
@@ -78,6 +83,7 @@ properties:
               - title
               - context
               - url
+              - method
               - description
       additionalProperties: false
       required:

--- a/schemas/list-workers-response.yml
+++ b/schemas/list-workers-response.yml
@@ -85,7 +85,12 @@ properties:
           title:  "URL"
           description: {$const: action-url-description}
           type:    string
-          format:  uri
+        method:
+          title:  "Method"
+          description: |
+            Method to indicate the desired action to be performed for a given resource.
+          type:   string
+          enum:   ["GET", "POST", "PUT", "DELETE", "PATCH"]
         description:
           title:   "Description"
           description: |
@@ -96,6 +101,7 @@ properties:
         - title
         - context
         - url
+        - method
         - description
       additionalProperties: false
   continuationToken:

--- a/schemas/list-workers-response.yml
+++ b/schemas/list-workers-response.yml
@@ -90,7 +90,7 @@ properties:
           description: |
             Method to indicate the desired action to be performed for a given resource.
           type:   string
-          enum:   ["GET", "POST", "PUT", "DELETE", "PATCH"]
+          enum:   ["POST", "PUT", "DELETE", "PATCH"]
         description:
           title:   "Description"
           description: |

--- a/schemas/list-workertypes-response.yml
+++ b/schemas/list-workertypes-response.yml
@@ -84,7 +84,7 @@ properties:
           description: |
             Method to indicate the desired action to be performed for a given resource.
           type:   string
-          enum:   ["GET", "POST", "PUT", "DELETE", "PATCH"]
+          enum:   ["POST", "PUT", "DELETE", "PATCH"]
         description:
           title:   "Description"
           description: |

--- a/schemas/list-workertypes-response.yml
+++ b/schemas/list-workertypes-response.yml
@@ -79,7 +79,12 @@ properties:
           title:  "URL"
           description: {$const: action-url-description}
           type:    string
-          format:  uri
+        method:
+          title:  "Method"
+          description: |
+            Method to indicate the desired action to be performed for a given resource.
+          type:   string
+          enum:   ["GET", "POST", "PUT", "DELETE", "PATCH"]
         description:
           title:   "Description"
           description: |
@@ -90,6 +95,7 @@ properties:
         - title
         - context
         - url
+        - method
         - description
       additionalProperties: false
   continuationToken:

--- a/schemas/provisioner-response.yml
+++ b/schemas/provisioner-response.yml
@@ -69,7 +69,7 @@ properties:
           description: |
             Method to indicate the desired action to be performed for a given resource.
           type:   string
-          enum:   ["GET", "POST", "PUT", "DELETE", "PATCH"]
+          enum:   ["POST", "PUT", "DELETE", "PATCH"]
         description:
           title:   "Description"
           description: |

--- a/schemas/provisioner-response.yml
+++ b/schemas/provisioner-response.yml
@@ -64,7 +64,12 @@ properties:
           title:  "URL"
           description: {$const: action-url-description}
           type:    string
-          format:  uri
+        method:
+          title:  "Method"
+          description: |
+            Method to indicate the desired action to be performed for a given resource.
+          type:   string
+          enum:   ["GET", "POST", "PUT", "DELETE", "PATCH"]
         description:
           title:   "Description"
           description: |
@@ -76,6 +81,7 @@ properties:
         - title
         - context
         - url
+        - method
         - description
 additionalProperties: false
 required:

--- a/schemas/update-provisioner-request.yml
+++ b/schemas/update-provisioner-request.yml
@@ -50,7 +50,12 @@ properties:
           title:  "URL"
           description: {$const: action-url-description}
           type:   string
-          format: uri
+        method:
+          title:  "Method"
+          description: |
+            Method to indicate the desired action to be performed for a given resource.
+          type:   string
+          enum:   ["GET", "POST", "PUT", "DELETE", "PATCH"]
         description:
           title:  "Description"
           description: |
@@ -62,5 +67,6 @@ properties:
         - title
         - context
         - url
+        - method
         - description
 additionalProperties: false

--- a/schemas/update-provisioner-request.yml
+++ b/schemas/update-provisioner-request.yml
@@ -30,15 +30,7 @@ properties:
     items:
       type:       object
       title:      Actions
-      description: |
-        Actions are defined on the provisioner. When an action is triggered,
-        it will use the `url` and `context` property to construct the URL and
-        perform a `POST` request. Note that the request will be signed with the
-        user's Taskcluster credentials.
-        If `url='https://hardware-provisioner.mozilla-releng.net/v1/power-cycle'`
-        and `context=‘worker-type’` for instance, the constructed URL will be
-        `'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle?provisionerId=${PROVISIONER_ID}&workerType=${WORKER_TYPE}`.
-        In other words, `url` handles the path name and `context` constructs the query string.
+      description: {$const: action-description}
       properties:
         name:
           title:  "Name"

--- a/schemas/update-provisioner-request.yml
+++ b/schemas/update-provisioner-request.yml
@@ -55,7 +55,7 @@ properties:
           description: |
             Method to indicate the desired action to be performed for a given resource.
           type:   string
-          enum:   ["GET", "POST", "PUT", "DELETE", "PATCH"]
+          enum:   ["POST", "PUT", "DELETE", "PATCH"]
         description:
           title:  "Description"
           description: |

--- a/schemas/workertype-response.yml
+++ b/schemas/workertype-response.yml
@@ -77,7 +77,7 @@ properties:
           description: |
             Method to indicate the desired action to be performed for a given resource.
           type:   string
-          enum:   ["GET", "POST", "PUT", "DELETE", "PATCH"]
+          enum:   ["POST", "PUT", "DELETE", "PATCH"]
         description:
           title:   "Description"
           description: |

--- a/schemas/workertype-response.yml
+++ b/schemas/workertype-response.yml
@@ -72,7 +72,12 @@ properties:
           title:  "URL"
           description: {$const: action-url-description}
           type:    string
-          format:  uri
+        method:
+          title:  "Method"
+          description: |
+            Method to indicate the desired action to be performed for a given resource.
+          type:   string
+          enum:   ["GET", "POST", "PUT", "DELETE", "PATCH"]
         description:
           title:   "Description"
           description: |
@@ -83,6 +88,7 @@ properties:
         - title
         - context
         - url
+        - method
         - description
       additionalProperties: false
 additionalProperties: false

--- a/test/workerinfo_test.js
+++ b/test/workerinfo_test.js
@@ -118,12 +118,14 @@ suite('provisioners and worker-types', () => {
         title: 'Kill Provisioner',
         context: 'provisioner',
         url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/<provisionerId>',
+        method: 'DELETE',
         description: 'Remove provisioner prov-B',
       }, {
         name: 'kill',
         title: 'Kill Worker Type',
         context: 'worker-type',
         url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/<provisionerId>/<workerType>',
+        method: 'DELETE',
         description: 'Remove worker type',
       }],
     };
@@ -267,12 +269,14 @@ suite('provisioners and worker-types', () => {
         title: 'Kill Provisioner',
         context: 'provisioner',
         url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/<provisionerId>',
+        method: 'DELETE',
         description: 'Remove provisioner prov-B',
       }, {
         name: 'kill',
         title: 'Kill Worker',
         context: 'worker',
         url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/<workerGroup>/<workerId>',
+        method: 'DELETE',
         description: 'Remove worker',
       }],
     };
@@ -435,12 +439,14 @@ suite('provisioners and worker-types', () => {
         title: 'Kill Provisioner',
         context: 'provisioner',
         url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/<provisionerId>',
+        method: 'DELETE',
         description: 'Remove provisioner prov-B',
       }, {
         name: 'kill',
         title: 'Kill Worker Type',
         context: 'worker-type',
         url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/<provisionerId>/<workerType>',
+        method: 'DELETE',
         description: 'Remove worker type',
       }],
     };
@@ -532,6 +538,7 @@ suite('provisioners and worker-types', () => {
         title: 'Kill Provisioner',
         context: 'provisioner',
         url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/<provisionerId>',
+        method: 'DELETE',
         description: 'Remove provisioner desc-provisioner',
       }],
     };
@@ -564,6 +571,7 @@ suite('provisioners and worker-types', () => {
       title: 'Kill Provisioner',
       context: 'provisioner',
       url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/<provisionerId>',
+      method: 'DELETE',
       description: 'Remove provisioner desc-provisioner',
     };
 
@@ -572,6 +580,7 @@ suite('provisioners and worker-types', () => {
       title: 'Reboot Provisioner',
       context: 'provisioner',
       url: 'https://hardware-provisioner.mozilla-releng.net/v1/reboot/<provisionerId>',
+      method: 'DELETE',
       description: 'Reboot provisioner desc-provisioner',
     };
 

--- a/test/workerinfo_test.js
+++ b/test/workerinfo_test.js
@@ -117,13 +117,13 @@ suite('provisioners and worker-types', () => {
         name: 'kill',
         title: 'Kill Provisioner',
         context: 'provisioner',
-        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle',
+        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/:provisionerId',
         description: 'Remove provisioner prov-B',
       }, {
         name: 'kill',
         title: 'Kill Worker Type',
         context: 'worker-type',
-        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle',
+        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/:provisionerId/:workerType',
         description: 'Remove worker type',
       }],
     };
@@ -266,13 +266,13 @@ suite('provisioners and worker-types', () => {
         name: 'kill',
         title: 'Kill Provisioner',
         context: 'provisioner',
-        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle',
+        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/:provisionerId',
         description: 'Remove provisioner prov-B',
       }, {
         name: 'kill',
         title: 'Kill Worker',
         context: 'worker',
-        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle',
+        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/:workerGroup/:workerId',
         description: 'Remove worker',
       }],
     };
@@ -434,13 +434,13 @@ suite('provisioners and worker-types', () => {
         name: 'kill',
         title: 'Kill Provisioner',
         context: 'provisioner',
-        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle',
+        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/:provisionerId',
         description: 'Remove provisioner prov-B',
       }, {
         name: 'kill',
         title: 'Kill Worker Type',
         context: 'worker-type',
-        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle',
+        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/:provisionerId/:workerType',
         description: 'Remove worker type',
       }],
     };
@@ -531,7 +531,7 @@ suite('provisioners and worker-types', () => {
         name: 'kill',
         title: 'Kill Provisioner',
         context: 'provisioner',
-        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle',
+        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/:provisionerId',
         description: 'Remove provisioner desc-provisioner',
       }],
     };
@@ -563,7 +563,7 @@ suite('provisioners and worker-types', () => {
       name: 'kill',
       title: 'Kill Provisioner',
       context: 'provisioner',
-      url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle',
+      url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/:provisionerId',
       description: 'Remove provisioner desc-provisioner',
     };
 
@@ -571,7 +571,7 @@ suite('provisioners and worker-types', () => {
       name: 'reboot',
       title: 'Reboot Provisioner',
       context: 'provisioner',
-      url: 'https://hardware-provisioner.mozilla-releng.net/v1/reboot',
+      url: 'https://hardware-provisioner.mozilla-releng.net/v1/reboot/:provisionerId',
       description: 'Reboot provisioner desc-provisioner',
     };
 

--- a/test/workerinfo_test.js
+++ b/test/workerinfo_test.js
@@ -117,13 +117,13 @@ suite('provisioners and worker-types', () => {
         name: 'kill',
         title: 'Kill Provisioner',
         context: 'provisioner',
-        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/:provisionerId',
+        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/<provisionerId>',
         description: 'Remove provisioner prov-B',
       }, {
         name: 'kill',
         title: 'Kill Worker Type',
         context: 'worker-type',
-        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/:provisionerId/:workerType',
+        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/<provisionerId>/<workerType>',
         description: 'Remove worker type',
       }],
     };
@@ -266,13 +266,13 @@ suite('provisioners and worker-types', () => {
         name: 'kill',
         title: 'Kill Provisioner',
         context: 'provisioner',
-        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/:provisionerId',
+        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/<provisionerId>',
         description: 'Remove provisioner prov-B',
       }, {
         name: 'kill',
         title: 'Kill Worker',
         context: 'worker',
-        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/:workerGroup/:workerId',
+        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/<workerGroup>/<workerId>',
         description: 'Remove worker',
       }],
     };
@@ -434,13 +434,13 @@ suite('provisioners and worker-types', () => {
         name: 'kill',
         title: 'Kill Provisioner',
         context: 'provisioner',
-        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/:provisionerId',
+        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/<provisionerId>',
         description: 'Remove provisioner prov-B',
       }, {
         name: 'kill',
         title: 'Kill Worker Type',
         context: 'worker-type',
-        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/:provisionerId/:workerType',
+        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/<provisionerId>/<workerType>',
         description: 'Remove worker type',
       }],
     };
@@ -531,7 +531,7 @@ suite('provisioners and worker-types', () => {
         name: 'kill',
         title: 'Kill Provisioner',
         context: 'provisioner',
-        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/:provisionerId',
+        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/<provisionerId>',
         description: 'Remove provisioner desc-provisioner',
       }],
     };
@@ -563,7 +563,7 @@ suite('provisioners and worker-types', () => {
       name: 'kill',
       title: 'Kill Provisioner',
       context: 'provisioner',
-      url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/:provisionerId',
+      url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/<provisionerId>',
       description: 'Remove provisioner desc-provisioner',
     };
 
@@ -571,7 +571,7 @@ suite('provisioners and worker-types', () => {
       name: 'reboot',
       title: 'Reboot Provisioner',
       context: 'provisioner',
-      url: 'https://hardware-provisioner.mozilla-releng.net/v1/reboot/:provisionerId',
+      url: 'https://hardware-provisioner.mozilla-releng.net/v1/reboot/<provisionerId>',
       description: 'Reboot provisioner desc-provisioner',
     };
 


### PR DESCRIPTION
The best option here is to switch actions back to allowing substitution in the URL path. This pull-request modifies the action explanations to talk about path parameters.