### PR TITLE
Make listWorkerTypes & listWorkers return good actions

### DIFF
--- a/schemas/list-workers-response.yml
+++ b/schemas/list-workers-response.yml
@@ -80,7 +80,7 @@ properties:
           title:  "Context"
           description: {$const: action-context-description}
           type:   string
-          enum:   ["worker"]
+          enum:   ["worker-type"]
         url:
           title:  "URL"
           description: {$const: action-url-description}

--- a/schemas/list-workertypes-response.yml
+++ b/schemas/list-workertypes-response.yml
@@ -74,7 +74,7 @@ properties:
           title:  "Context"
           description: {$const: action-context-description}
           type:   string
-          enum:   ["worker-type"]
+          enum:   ["provisioner"]
         url:
           title:  "URL"
           description: {$const: action-url-description}

--- a/src/api.js
+++ b/src/api.js
@@ -2232,7 +2232,7 @@ api.declare({
     this.Provisioner.load({provisionerId}, true),
   ]);
 
-  const actions = provisioner ? provisioner.actions.filter(action => action.context === 'worker-type') : [];
+  const actions = provisioner ? provisioner.actions.filter(action => action.context === 'provisioner') : [];
 
   const result = {
     workerTypes: workerTypes.entries.map(workerType => workerType.json()),
@@ -2390,7 +2390,7 @@ api.declare({
     await this.Provisioner.load({provisionerId}, true),
   ]);
 
-  const actions = provisioner ? provisioner.actions.filter(action => action.context === 'worker') : [];
+  const actions = provisioner ? provisioner.actions.filter(action => action.context === 'worker-type') : [];
 
   const result = {
     workers: workers.entries.map(worker => {

--- a/test/workerinfo_test.js
+++ b/test/workerinfo_test.js
@@ -147,7 +147,7 @@ suite('provisioners and worker-types', () => {
     assert(result.workerTypes.length === 1, 'expected workerTypes');
     assert(result.workerTypes[0].workerType === wType.workerType, `expected ${wType.workerType}`);
     assert(result.actions.length === 1, 'expected 1 action');
-    assert(result.actions[0].context === 'worker-type', 'expected action with context worker-type');
+    assert(result.actions[0].context === 'provisioner', 'expected action with context provisioner');
   });
 
   test('list worker-types (limit and continuationToken)', async () => {
@@ -273,11 +273,11 @@ suite('provisioners and worker-types', () => {
         description: 'Remove provisioner prov-B',
       }, {
         name: 'kill',
-        title: 'Kill Worker',
-        context: 'worker',
-        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/<workerGroup>/<workerId>',
+        title: 'Kill Worker Type',
+        context: 'worker-type',
+        url: 'https://hardware-provisioner.mozilla-releng.net/v1/power-cycle/<workerType>',
         method: 'DELETE',
-        description: 'Remove worker',
+        description: 'Remove worker-type',
       }],
     };
 
@@ -300,7 +300,7 @@ suite('provisioners and worker-types', () => {
     assert(result.workers.length === 1, 'expected workers');
     assert(result.workers[0].workerId === worker.workerId, `expected ${worker.workerId}`);
     assert(result.actions.length === 1, 'expected 1 action');
-    assert(result.actions[0].context === 'worker', 'expected action with context worker');
+    assert(result.actions[0].context === 'worker-type', 'expected action with context worker-type');
   });
 
   test('queue.listWorkers returns filtered workers', async () => {


### PR DESCRIPTION
`listWorkerTypes()`  and `listWorkers()` should return actions with `context=provisioner` and `context=worker-type` respectively.