### PR TITLE
Expand Queue Actions documentation

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -1,16 +1,30 @@
 ---
 title: Actions
-description: How actions are defined on the provisioner.
+description: Queue Actions
+order: 40
 ---
 
-Actions can be performed on provisioners, worker-types and workers. An example of an action
-can be to kill all instances of a workerType. Each action has a `context` that is one of
-`provisioner`, `worker-type`, or `worker`, indicating which it applies to. For example,
-an action to kill a worker will have a `context=worker` since it's operating on the worker level.
+The queue allows users to define "actions" on [provisioner, worker type, and
+worker](worker-hierarchy) resources. These actions can then be executed by
+other components for their side-effects on the resources.  An example of an
+action can be to kill all instances of a workerType.
+
+Each action has a `context` that is one of `provisioner`, `worker-type`, or
+`worker`, indicating which it applies to. For example, an action to kill a
+worker will have a `context=worker` since it's operating on the worker level.
+An action to reboot a single worker would have `context=worker`.
+
+Queue Actions are conceptually related to [task
+actions](/manual/using/actions), in that both allow resources to expose
+context-specific opportunities to manipulate those resources.  However, the
+implementations are completely different.
 
 ## Defining Actions
-To add an action to a provisioner, perform a call to the queue's `declareProvisioner` method,
-supplying a list of actions.
+
+Actions are defined at the provisioner level. To set the actions to a
+provisioner, perform a call to the queue's
+[declareProvisioner](/reference/platform/taskcluster-queue/references/api#declareProvisioner)
+method, supplying a list of actions.
 
 An action is comprised with the following properties:
 
@@ -20,20 +34,26 @@ An action is comprised with the following properties:
 | `title`       | string                                        | ✓         | A human readable string intended to be used as label on the button, link or menu entry that triggers the action. This should be short and concise. Ideally, you'll want to avoid duplicates.                                                        |
 | `context`     | enum('provisioner', 'worker-type', 'worker')  | ✓         | Actions have a "context" that is one of `provisioner`, `worker-type`, or `worker`, indicating which it applies to.                                                                                                                                  |
 | `url`         | string                                        | ✓         | URL to use for the request.                                                                                                                                                                                                                         |
-| `method`      | enum('POST', 'PUT', 'DELETE', 'PATCH')        | ✓         | Method to indicate the desired action to be performed for a given resource.                                                                                                                                                                         |
+| `method`      | enum('POST', 'PUT', 'DELETE', 'PATCH')        | ✓         | HTTP Method to use for the request.                                                                                                                                                                                                                 |
 | `description` | string                                        | ✓         | A human readable string describing the action, such as what it does, how it does it, what it is useful for. This string is to be render as markdown, allowing for bullet points, links and other simple formatting to explain what the action does. |
 
 ### Context
-Actions have a "context" that is one of `provisioner`, `worker-type`, or `worker`, indicating which it applies to. `context`
-is used by the front-end to know where to display the action.
 
-| `context`     | Page displayed        |
-|---------------|-----------------------|
-| `provisioner` | Provisioner Explorer  |
-| `worker-type` | Workers Explorer      |
-| `worker`      | Worker Explorer       |
+Actions have a "context" that is one of `provisioner`, `worker-type`, or `worker`, indicating which it applies to.  Actions
+specific to a context will only be returned by the appropriate API method.
 
-## How to trigger an action
+| `context`     | API Method                                                                             |
+|---------------|----------------------------------------------------------------------------------------|
+| `provisioner` | [getProvisioner](/reference/platform/taskcluster-queue/references/api#getProvisioner)* |
+| `worker-type` | [getWorkerType](/reference/platform/taskcluster-queue/references/api#getWorkerType)    |
+| `worker`      | [getWorker](/reference/platform/taskcluster-queue/references/api#getWorker)            |
+
+Note that all actions are declared at the provisioner level, regardless of
+context.  For symmetry, `getProvisioner` also returns all actions, not just
+those with `context=provisioner`.
+
+## Triggering Actions in a User Interface
+
 To trigger an action, use the action's `url` and `method` properties to make a request to it.
 Depending on the action's `context`, substitute the following parameters in the `url`:
 
@@ -42,7 +62,10 @@ Depending on the action's `context`, substitute the following parameters in the 
 | provisioner | `<provisionerId>`                                                |
 | worker-type | `<provisionerId>`, `<workerType>`                                |
 | worker      | `<provisionerId>`, `<workerType>`, `<workerGroup>`, `<workerId>` |
-  
+
+If the action is initiated by a user, it should have the user's Taskcluster
+credentials attached.
+
 _Example:_
 
 For the following action:
@@ -62,5 +85,13 @@ The `DELETE` request will be:
 ```
 https://ec2-manager.taskcluster.net/v1/region/${workerGroup}/instance/${workerId}
 ```
+## Triggering Actions in Automation
 
-_Note: The request is made with Taskcluster credentials._
+An automated system that needs to trigger an action should call the appropriate
+API method (e.g., `getWorkerType`) to find the available actions, and then
+search for the desired action by exact match against the `name` property. This
+allows modification of an action's title without breaking existing automation.
+
+Having found the action, follow the same process as above for generating the
+URL and method. A service will generally use its own permanent Taskcluster
+credentials to make the HTTP request.

--- a/docs/superseding.md
+++ b/docs/superseding.md
@@ -1,5 +1,6 @@
 ---
 title: Superseding
+order: 40
 ---
 
 In many cases, executing some tasks in the queue can render others unnecessary.

--- a/docs/task-life-cycle.md
+++ b/docs/task-life-cycle.md
@@ -1,6 +1,7 @@
 ---
 title: Task Life-Cycle
 description: Phases of a task life-cycle.
+order: 50
 ---
 The diagram below outlines the task life-cycle. Transitions drawn by solid
 black lines are initiated by workers. While dashes transitions are initiated

--- a/docs/task-schema.md
+++ b/docs/task-schema.md
@@ -7,6 +7,7 @@ ejs:          true
 superagent:   true
 docref:       true
 title:        "Task Schema"
+order: 100
 ---
 
 # Task Definition

--- a/docs/worker-hierarchy.md
+++ b/docs/worker-hierarchy.md
@@ -1,0 +1,41 @@
+---
+title: Worker Hierarchy
+order: 30
+---
+
+The queue defines a hierarchy of resources that consume tasks from queues:
+
+## Provisioners
+
+[Provisioners](/manual/task-execution/provisioning), identified with a
+`provisionerId`, are responsible for groups of worker types. While some
+provisioners, such as the AWS provisioner, are active software components,
+others are simply identifiers within the Queue service's data structures.  For
+example, there is no active management of the
+[`releng-hardware`](https://tools.taskcluster.net/provisioners/releng-hardware)
+`provisionerId`.
+
+Provisioners can be declared, and metadata associated with them, via the
+[declareProvisioner](/reference/platform/taskcluster-queue/references/api#declareProvisioner)
+API method.
+
+## Worker Types
+
+[Worker Types](/manual/tasks/workertypes), identified by
+`provisionerId/workerType`, are nested under a single provisioner and gather
+interchangeable workers that can all perform the same work. Tasks are queued
+for a specific worker type, and workers claim work for a single worker type.
+
+Worker types can be declared, and metadata associated with them, via the
+[declareWorkerType](/reference/platform/taskcluster-queue/references/api#declareWorkerType)
+API method.
+
+## Workers
+
+[Workers](/manual/task-execution/workers) are the entities that actually
+perform work, and are identified by `workerGroup/workerId`. A worker claims and
+performs work from a single worker type.
+
+Workers can be declared, and metadata associated with them, via the
+[declareWorker](/reference/platform/taskcluster-queue/references/api#declareWorker)
+API method.

--- a/docs/worker-interaction.md
+++ b/docs/worker-interaction.md
@@ -1,6 +1,7 @@
 ---
 title: Queue-Worker Interaction
 description: How workers interacts with the queue to process tasks.
+order: 60
 ---
 _This document outlines how workers interact with the queue in-order to process
 tasks. This is intended as required reading for any worker-implementor._


### PR DESCRIPTION
This
 * defines the provisioner / worker-type / worker hierarchy a little
   better
 * distinguishes queue actions from task actions
 * removes specific reference to the tools UI views
 * gives more detail on how calls can occur from automation, including
   use of the `name` property

It presupposes some planned changes to the queue APIs; in particular,
that actions be returned from the getXxx methods and not from the
listXxx methods.