### PR TITLE
Remove actions when listing workerTypes and workers

### DIFF
--- a/schemas/list-workers-response.yml
+++ b/schemas/list-workers-response.yml
@@ -63,50 +63,6 @@ properties:
               minimum:          {$const: min-run-id}
               maximum:          {$const: max-run-id}
       additionalProperties: false
-  actions:
-    type:         array
-    items:
-      type:       object
-      title:      Actions
-      description: {$const: action-description}
-      properties:
-        name:
-          title:  "Name"
-          description: |
-            Short names for things like logging/error messages.
-          type:   string
-        title:
-          title:  "Title"
-          description: |
-            Appropriate title for any sort of Modal prompt.
-        context:
-          title:  "Context"
-          description: {$const: action-context-description}
-          type:   string
-          enum:   ["worker"]
-        url:
-          title:  "URL"
-          description: {$const: action-url-description}
-          type:    string
-        method:
-          title:  "Method"
-          description: |
-            Method to indicate the desired action to be performed for a given resource.
-          type:   string
-          enum:   ["POST", "PUT", "DELETE", "PATCH"]
-        description:
-          title:   "Description"
-          description: |
-            Description of the provisioner.
-          type:    string
-      required:
-        - name
-        - title
-        - context
-        - url
-        - method
-        - description
-      additionalProperties: false
   continuationToken:
     type:           string
     title:          "Continuation Token"
@@ -121,4 +77,3 @@ properties:
 additionalProperties: false
 required:
  - workers
- - actions

--- a/schemas/list-workertypes-response.yml
+++ b/schemas/list-workertypes-response.yml
@@ -54,50 +54,6 @@ properties:
           type:         string
           format:       date-time
       additionalProperties: false
-  actions:
-    type:         array
-    items:
-      type:       object
-      title:      Actions
-      description: {$const: action-description}
-      properties:
-        name:
-          title:  "Name"
-          description: |
-            Short names for things like logging/error messages.
-          type:   string
-        title:
-          title:  "Title"
-          description: |
-            Appropriate title for any sort of Modal prompt.
-        context:
-          title:  "Context"
-          description: {$const: action-context-description}
-          type:   string
-          enum:   ["worker-type"]
-        url:
-          title:  "URL"
-          description: {$const: action-url-description}
-          type:    string
-        method:
-          title:  "Method"
-          description: |
-            Method to indicate the desired action to be performed for a given resource.
-          type:   string
-          enum:   ["POST", "PUT", "DELETE", "PATCH"]
-        description:
-          title:   "Description"
-          description: |
-            Description of the provisioner.
-          type:    string
-      required:
-        - name
-        - title
-        - context
-        - url
-        - method
-        - description
-      additionalProperties: false
   continuationToken:
     type:               string
     title:              "Continuation Token"
@@ -112,4 +68,3 @@ properties:
 additionalProperties: false
 required:
  - workerTypes
- - actions

--- a/src/api.js
+++ b/src/api.js
@@ -2227,16 +2227,10 @@ api.declare({
   const provisionerId = req.params.provisionerId;
   const limit = Math.min(1000, parseInt(req.query.limit || 1000, 10));
 
-  const [workerTypes, provisioner] = await Promise.all([
-    this.WorkerType.scan({provisionerId}, {continuation, limit}),
-    this.Provisioner.load({provisionerId}, true),
-  ]);
-
-  const actions = provisioner ? provisioner.actions.filter(action => action.context === 'worker-type') : [];
+  const workerTypes = await this.WorkerType.scan({provisionerId}, {continuation, limit});
 
   const result = {
     workerTypes: workerTypes.entries.map(workerType => workerType.json()),
-    actions: actions || [],
   };
 
   if (workerTypes.continuation) {
@@ -2389,12 +2383,7 @@ api.declare({
     workerQuery.quarantineUntil = Entity.op.lessThan(now);
   }
 
-  const [workers, provisioner] = await Promise.all([
-    await this.Worker.scan(workerQuery, {continuation, limit}),
-    await this.Provisioner.load({provisionerId}, true),
-  ]);
-
-  const actions = provisioner ? provisioner.actions.filter(action => action.context === 'worker') : [];
+  const workers = await this.Worker.scan(workerQuery, {continuation, limit});
 
   const result = {
     workers: workers.entries.map(worker => ({
@@ -2406,7 +2395,6 @@ api.declare({
         worker.quarantineUntil.toJSON() :
         null,
     })),
-    actions: actions || [],
   };
 
   if (workers.continuation) {

--- a/test/workerinfo_test.js
+++ b/test/workerinfo_test.js
@@ -146,8 +146,6 @@ suite('provisioners and worker-types', () => {
 
     assert(result.workerTypes.length === 1, 'expected workerTypes');
     assert(result.workerTypes[0].workerType === wType.workerType, `expected ${wType.workerType}`);
-    assert(result.actions.length === 1, 'expected 1 action');
-    assert(result.actions[0].context === 'worker-type', 'expected action with context worker-type');
   });
 
   test('list worker-types (limit and continuationToken)', async () => {
@@ -299,8 +297,6 @@ suite('provisioners and worker-types', () => {
 
     assert(result.workers.length === 1, 'expected workers');
     assert(result.workers[0].workerId === worker.workerId, `expected ${worker.workerId}`);
-    assert(result.actions.length === 1, 'expected 1 action');
-    assert(result.actions[0].context === 'worker', 'expected action with context worker');
   });
 
   test('queue.listWorkers returns filtered workers', async () => {


### PR DESCRIPTION
Actions are not needed when listing workers or worker-types. When a worker-type requests a list of workers for example, the worker-type will then need to make a request to `getWorkerType()` to get the list of actions with  `context=worker-type`.