### PR TITLE
Make property optional rather than returning null value

### DIFF
--- a/schemas/list-workers-response.yml
+++ b/schemas/list-workers-response.yml
@@ -33,7 +33,7 @@ properties:
             Once the quarantineUntil time has elapsed, the worker resumes accepting jobs.
             Note that a quarantine can be lifted by setting `quarantineUntil` to the present time (or
             somewhere in the past).
-          type:         ["string", "null"]
+          type:         string
           format:       date-time
         firstClaim:
           title:        "First task claimed"
@@ -62,7 +62,16 @@ properties:
               type:             integer
               minimum:          {$const: min-run-id}
               maximum:          {$const: max-run-id}
+          required:
+            - taskId
+            - runId
+          additionalProperties: false
       additionalProperties: false
+      required:
+        - workerGroup
+        - workerId
+        - firstClaim
+        - latestTask
   continuationToken:
     type:           string
     title:          "Continuation Token"

--- a/schemas/list-workers-response.yml
+++ b/schemas/list-workers-response.yml
@@ -71,7 +71,6 @@ properties:
         - workerGroup
         - workerId
         - firstClaim
-        - latestTask
   continuationToken:
     type:           string
     title:          "Continuation Token"

--- a/src/api.js
+++ b/src/api.js
@@ -2391,13 +2391,15 @@ api.declare({
         workerGroup: worker.workerGroup,
         workerId: worker.workerId,
         firstClaim: worker.firstClaim.toJSON(),
-        latestTask: worker.recentTasks.pop(),
       };
+      if (worker.recentTasks.length > 0) {
+        entry.latestTask = worker.recentTasks[worker.recentTasks.length - 1];
+      }
       if (worker.quarantineUntil.getTime() > now.getTime()) {
         entry.quarantineUntil = worker.quarantineUntil.toJSON();
       }
       return entry;
-    })
+    }),
   };
 
   if (workers.continuation) {

--- a/src/api.js
+++ b/src/api.js
@@ -2386,15 +2386,18 @@ api.declare({
   const workers = await this.Worker.scan(workerQuery, {continuation, limit});
 
   const result = {
-    workers: workers.entries.map(worker => ({
-      workerGroup: worker.workerGroup,
-      workerId: worker.workerId,
-      firstClaim: worker.firstClaim.toJSON(),
-      latestTask: worker.recentTasks.pop(),
-      quarantineUntil: worker.quarantineUntil.getTime() > now.getTime() ?
-        worker.quarantineUntil.toJSON() :
-        null,
-    })),
+    workers: workers.entries.map(worker => {
+      let entry = {
+        workerGroup: worker.workerGroup,
+        workerId: worker.workerId,
+        firstClaim: worker.firstClaim.toJSON(),
+        latestTask: worker.recentTasks.pop(),
+      };
+      if (worker.quarantineUntil.getTime() > now.getTime()) {
+        entry.quarantineUntil = worker.quarantineUntil.toJSON();
+      }
+      return entry;
+    })
   };
 
   if (workers.continuation) {

--- a/test/workerinfo_test.js
+++ b/test/workerinfo_test.js
@@ -241,7 +241,7 @@ suite('provisioners and worker-types', () => {
     assert(result.workers.length === 1, 'expected workers');
     assert(result.workers[0].workerGroup === worker.workerGroup, `expected ${worker.workerGroup}`);
     assert(result.workers[0].workerId === worker.workerId, `expected ${worker.workerId}`);
-    assert(result.workers[0].quarantineUntil === null, 'expected quarantineUntil to be null');
+    assert(!result.workers[0].quarantineUntil, 'expected quarantineUntil to not be defined');
     assert(result.workers[0].latestTask.taskId === taskId2, `expected ${taskId2}`);
     assert(
       new Date(result.workers[0].firstClaim).getTime() === worker.firstClaim.getTime(), `expected ${worker.firstClaim}`


### PR DESCRIPTION
Hi @helfi92,

Although it is entirely valid to specify `type` as the array `["string", "null"]` I think the advantage of making it an optional property is that if there is no value, `quarantineUntil` does not needed to be included, rather than `"quarantineUntil": null`.

I haven't tested this change, but I'm hoping the CI will take care of this, or you'll be able to let me know if I need to do any additional testing.

Note: the motivation for making this change is because it broke the code generation in taskcluster-client-go. Until now, we never had a type that permitted multiple values. I could resolve this by enhancing taskcluster-client-go too (which I will probably do) but in discovering this, I saw it was inconsistent with the way we manage optional fields in the rest of the project, so I thought it would make sense to align our schemas on how they handle optional values, to give a consistent treatment across our APIs/data structures.

Let me know what you think, or if you want to discuss it!

Thanks!