### PR TITLE
Bug 1249045 - issue named temporary credentials to tasks

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1650,9 +1650,20 @@ api.declare({
   }
 
   // Create temporary credentials for the task
+  let clientId = [
+    'task-client',
+    taskId,
+    `${runId}`,
+    'on',
+    run.workerGroup,
+    run.workerId,
+    'until',
+    `${takenUntil.getTime() / 1000}`,
+  ].join('/');
   let credentials = taskcluster.createTemporaryCredentials({
-    start:  new Date(Date.now() - 15 * 60 * 1000),
-    expiry: new Date(takenUntil.getTime() + 15 * 60 * 1000),
+    clientId,
+    start:  new Date(),
+    expiry: takenUntil,
     scopes: [
       'queue:reclaim-task:' + taskId + '/' + runId,
       'queue:resolve-task:' + taskId + '/' + runId,

--- a/src/task-creds.js
+++ b/src/task-creds.js
@@ -1,0 +1,30 @@
+let taskcluster = require('taskcluster-client');
+
+/**
+ * Creates temporary credentials for a task run.
+ */
+var taskCredentials = function(taskId, runId, workerGroup, workerId, takenUntil, scopes, permaCreds) {
+  let clientId = [
+    'task-client',
+    taskId,
+    `${runId}`,
+    'on',
+    workerGroup,
+    workerId,
+    'until',
+    `${takenUntil.getTime() / 1000}`,
+  ].join('/');
+  return taskcluster.createTemporaryCredentials({
+    clientId,
+    start:  new Date(),
+    expiry: takenUntil,
+    scopes: [
+      'queue:reclaim-task:' + taskId + '/' + runId,
+      'queue:resolve-task:' + taskId + '/' + runId,
+      'queue:create-artifact:' + taskId + '/' + runId,
+    ].concat(scopes),
+    credentials: permaCreds,
+  });
+};
+
+module.exports = taskCredentials;

--- a/src/workclaimer.js
+++ b/src/workclaimer.js
@@ -2,6 +2,7 @@ let assert      = require('assert');
 let _           = require('lodash');
 let events      = require('events');
 let taskcluster = require('taskcluster-client');
+let taskCreds   = require('./task-creds');
 let Promise     = require('promise');
 
 /**
@@ -276,28 +277,15 @@ class WorkClaimer extends events.EventEmitter {
       takenUntil:   run.takenUntil,
     }, task.routes);
 
-    // Create temporary credentials for the task
-    let clientId = [
-      'task-client',
+    let credentials = taskCreds(
       taskId,
-      `${runId}`,
-      'on',
+      runId,
       workerGroup,
       workerId,
-      'until',
-      `${takenUntil.getTime() / 1000}`,
-    ].join('/');
-    let credentials = taskcluster.createTemporaryCredentials({
-      clientId,
-      start:  new Date(),
-      expiry: takenUntil,
-      scopes: [
-        'queue:reclaim-task:' + taskId + '/' + runId,
-        'queue:resolve-task:' + taskId + '/' + runId,
-        'queue:create-artifact:' + taskId + '/' + runId,
-      ].concat(task.scopes),
-      credentials: this._credentials,
-    });
+      takenUntil,
+      task.scopes,
+      this._credentials,
+    );
 
     // Return claim structure
     return {

--- a/src/workclaimer.js
+++ b/src/workclaimer.js
@@ -289,8 +289,8 @@ class WorkClaimer extends events.EventEmitter {
     ].join('/');
     let credentials = taskcluster.createTemporaryCredentials({
       clientId,
-      start:  new Date(Date.now() - 15 * 60 * 1000),
-      expiry: new Date(takenUntil.getTime() + 15 * 60 * 1000),
+      start:  new Date(),
+      expiry: takenUntil,
       scopes: [
         'queue:reclaim-task:' + taskId + '/' + runId,
         'queue:resolve-task:' + taskId + '/' + runId,


### PR DESCRIPTION
I haven't run any tests locally, hoping travis will take care of that for me. :-)

Note, since auth now applies clock drift adjustment, this is also no longer necessary in the queue, so have removed that too.

Note, the temp credential naming schema I used is based on the scheme defined already in [our docs](https://github.com/taskcluster/taskcluster-docs/blob/ce34244bd65917485c2120e308c097c9ff5157b9/src/manual/design/namespaces.md#clients).