### PR TITLE
Upgrade taskcluster-lib-api version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "request-ip": "^2.0.2",
     "slugid": "^1.1.0",
     "taskcluster-client": "^3.1.1",
-    "taskcluster-lib-api": "^6.0.4",
+    "taskcluster-lib-api": "^7.0.1",
     "taskcluster-lib-app": "^3.0.0",
     "taskcluster-lib-docs": "^4.1.1",
     "taskcluster-lib-loader": "^2.0.0",

--- a/src/api.js
+++ b/src/api.js
@@ -98,6 +98,7 @@ var api = new API({
     ' * Workers, who execute tasks, and',
     ' * Tools, that wants to inspect the state of a task.',
   ].join('\n'),
+  name:               'queue',
   schemaPrefix:       'http://schemas.taskcluster.net/queue/v1/',
   params: {
     taskId:           SLUGID_PATTERN,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2546,9 +2546,9 @@ taskcluster-client@^3.0.3, taskcluster-client@^3.1.0, taskcluster-client@^3.1.1:
     slugid "^1.1.0"
     superagent "~3.8.1"
 
-taskcluster-lib-api@^6.0.4:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/taskcluster-lib-api/-/taskcluster-lib-api-6.0.4.tgz#0c1a8cd37ab105caa85a217e6d11818d6a98ecca"
+taskcluster-lib-api@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-api/-/taskcluster-lib-api-7.0.1.tgz#7ce01219c2faaba0ec016578241cfdf541a95d89"
   dependencies:
     ajv "^5.3.0"
     aws-sdk "^2.151.0"


### PR DESCRIPTION
Upgrade taskcluster-lib-api version to the newest one. It is to
enable Access-Control-Max-Age, add name as options as it 
is required.

Related to Bug 1442636

@djmitche please review:D