### PR TITLE
Bug 1449848 - Escape markdown (by upgrading tc-lib-api)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "request-ip": "^2.0.2",
     "slugid": "^1.1.0",
     "taskcluster-client": "^3.1.1",
-    "taskcluster-lib-api": "8.0.0",
+    "taskcluster-lib-api": "8.1.0",
     "taskcluster-lib-app": "^3.0.0",
     "taskcluster-lib-docs": "^4.1.1",
     "taskcluster-lib-loader": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -737,6 +737,10 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
+escape-markdown@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/escape-markdown/-/escape-markdown-1.0.4.tgz#752d74bc7ae3fb0b7c684ead26aab4e5a78c4ff7"
+
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -2546,15 +2550,16 @@ taskcluster-client@^3.0.3, taskcluster-client@^3.1.0, taskcluster-client@^3.1.1:
     slugid "^1.1.0"
     superagent "~3.8.1"
 
-taskcluster-lib-api@8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/taskcluster-lib-api/-/taskcluster-lib-api-8.0.0.tgz#d459870d48134a3fdd14fc1c92b244807d6b7c2b"
+taskcluster-lib-api@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-api/-/taskcluster-lib-api-8.1.0.tgz#d1d0efef9a500be9450459bbc53d2e71ed046b04"
   dependencies:
     ajv "^5.3.0"
     aws-sdk "^2.151.0"
     babel-runtime "^6.26.0"
     body-parser "1.18.2"
     debug "^3.1.0"
+    escape-markdown "^1.0.4"
     express "4.16.2"
     hawk "6.0.2"
     lodash "^4.15.0"


### PR DESCRIPTION
This brings in https://github.com/taskcluster/taskcluster-lib-api/pull/91