### PR TITLE
Use relative links for svgs in docs

### DIFF
--- a/docs/task-life-cycle.md
+++ b/docs/task-life-cycle.md
@@ -7,7 +7,7 @@ The diagram below outlines the task life-cycle. Transitions drawn by solid
 black lines are initiated by workers. While dashes transitions are initiated
 at the initiative of the queue, or its consumers.
 
-![Task Life Cycle](task-life-cycle.svg)
+![Task Life Cycle](./task-life-cycle.svg)
 
 ## Unscheduled Tasks
 When a task is created it is _unscheduled_ until (i) it is scheduled by

--- a/docs/worker-interaction.md
+++ b/docs/worker-interaction.md
@@ -11,7 +11,7 @@ successfully claimed, executed and resolved. Obviously, there is a few corner
 cases when dealing with internal errors, invalid payloads and early worker
 termination, sections here outline how to handle all these cases.
 
-![Common queue-worker interaction](queue-worker-interaction.svg)
+![Common queue-worker interaction](./queue-worker-interaction.svg)
 
 
 ## Claiming Pending Tasks


### PR DESCRIPTION
The tools build process prefers this; otherwise, it doesn't really
matter..