### PR TITLE
Return 406 if Accept-Encoding doesn't match store Content-Encoding

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -110,6 +110,9 @@ var api = new API({
     runId:            RUN_ID_PATTERN,
     name:             /^[\x20-\x7e]+$/, // Artifact names must be printable ASCII
   },
+  errorCodes: {
+    ContentEncodingNotAvailable: 406,
+  },
   context: [
     'Task',               // data.Task instance
     'Artifact',           // data.Artifact instance

--- a/src/artifacts.js
+++ b/src/artifacts.js
@@ -514,7 +514,7 @@ var replyWithArtifact = async function(taskId, runId, name, req, res) {
         'available in one of these encodings.',
         '',
         'To download this artifact the request must support `Content-Encoding: {{contentEncoding}}`,',
-        'the request can indicating by setting `Accept-Encoding` accordingly.',
+        'try setting `Accept-Encoding: {{contentEncoding}}` and handle decoding.',
       ].join('\n'), {
         name,
         acceptEncoding: req.headers['accept-encoding'],

--- a/src/data.js
+++ b/src/data.js
@@ -377,14 +377,14 @@ let Artifact = Entity.configure({
      *   contentEncoding:   Content encoding, such as 'gzip',
      *                      NOTE: This property is not present if contentEncoding is 'identity'.
      *   contentSha256:     Hex encoded sha256 hash of the un-encoded artifact
-     *   contentLength:     Size of the un-encoded artifact
-     *   transferLength:    Size of the content-encoding encoded artifact,
+     *   contentLength:     Size of the un-encoded artifact as number of bytes
+     *   transferLength:    Size of the content-encoding encoded artifact as number of bytes,
      *                      NOTE: This property is not present if contentEncoding is 'identity'.
      *   transferSha256:    Hax encooded sha256 hash of the content-encoding encoded artifact,
      *                      NOTE: This property is not present if contentEncoding is 'identity'.
-     *   provider:          Always 's3'
-     *   region:            Always 'us-west-2'
-     *   bucket:            Always configured public or private bucket
+     *   provider:          Provider currently 's3'
+     *   region:            Region currently 'us-west-2'
+     *   bucket:            Bucket, currently configured public or private bucket
      *   key:               Path to the artifact in S3
      *   uploadId:          S3 multipart uploadId.
      *                      NOTE: This property is not present when upload is completed.

--- a/src/data.js
+++ b/src/data.js
@@ -372,21 +372,30 @@ let Artifact = Entity.configure({
      * storageType: error
      *   reason:        Formalized reason for error artifact, see JSON schema.
      *   message:       Human readable error message to return
+     *
      * storageType: blob
-     *   contentType
-     *   contentEncoding
-     *   contentSha256: SHA256 hash of the un-encoded artifact
-     *   contentLength: Number of bytes of the un-encoded artifact
-     *   transferSha256: SHA256 hash of the content-encoding encoded artifact
-     *   transferLength: Number of bytes of the content-encoding encoded artifact
-     *   partsHash: Rather than storing the potentially large list of sha256/size
-     *              pairings for each part, we just need to store enough information
-     *              to determine if the operation would result in an idempotency
-     *              error
+     *   contentEncoding:   Content encoding, such as 'gzip',
+     *                      NOTE: This property is not present if contentEncoding is 'identity'.
+     *   contentSha256:     Hex encoded sha256 hash of the un-encoded artifact
+     *   contentLength:     Size of the un-encoded artifact
+     *   transferLength:    Size of the content-encoding encoded artifact,
+     *                      NOTE: This property is not present if contentEncoding is 'identity'.
+     *   transferSha256:    Hax encooded sha256 hash of the content-encoding encoded artifact,
+     *                      NOTE: This property is not present if contentEncoding is 'identity'.
+     *   provider:          Always 's3'
+     *   region:            Always 'us-west-2'
+     *   bucket:            Always configured public or private bucket
+     *   key:               Path to the artifact in S3
+     *   uploadId:          S3 multipart uploadId.
+     *                      NOTE: This property is not present when upload is completed.
+     *   etag:              S3 ETag value.
+     *                      NOTE: This property is not present until upload is completed.
+     *   partsHash:         Hash of (sha256, size) tuples for all parts.
+     *                      We store this to enable idempotency, when a request is retried.
      */
     details:        Entity.types.JSON,
     expires:        Entity.types.Date,
-    /** 
+    /**
      * Present is a number field which represents an artifact being present and
      * the upload being completed.  The handling logic for the artifact's
      * storage type will fully define what that means for a given storage type.

--- a/test/artifact_test.js
+++ b/test/artifact_test.js
@@ -238,7 +238,7 @@ suite('Artifacts', function() {
 
     test('S3 single part complete flow, content-encoding: gzip', async () => {
       const taskId = slugid.v4();
-      const data = crypto.randomBytes(/*12 * 1024 * 1024 +*/ 21);
+      const data = crypto.randomBytes(12 * 1024 * 1024 + 21);
       const gzipped = zlib.gzipSync(data);
 
       debug('### Creating task');
@@ -262,13 +262,9 @@ suite('Artifacts', function() {
         contentSha256: crypto.createHash('sha256').update(data).digest('hex'),
         transferLength: gzipped.length,
         transferSha256: crypto.createHash('sha256').update(gzipped).digest('hex'),
-        parts: [{
-          size: gzipped.length,
-          sha256: crypto.createHash('sha256').update(gzipped).digest('hex'),
-        }],
       });
 
-      debug('### Put first part of artifact');
+      debug('### Put first and only part of artifact');
       const {method, url, headers} = requests[0];
       const res = await request(method, url).set(headers).send(gzipped);
       const etag = res.headers['etag'];


### PR DESCRIPTION
We only do this for new the `blob` artifacts, as they are not in wide-spread use yet.
Hence, as we adopt them people will have time to switch over.