### PR TITLE
Hopefully last round of cleanup

### DIFF
--- a/schemas/claim-work-response.yml
+++ b/schemas/claim-work-response.yml
@@ -10,6 +10,7 @@ properties:
       List of task claims, may be empty if no tasks was claimed, in which case
       the worker should sleep a tiny bit before polling again.
     items:
+      title:      "Task Claim"
       type:       object
       properties:
         status: {$ref: "http://schemas.taskcluster.net/queue/v1/task-status.json#"}
@@ -39,8 +40,8 @@ properties:
             with reason `claim-expired` if the run haven't been reclaimed.
           type:         string
           format:       date-time
-        task: {$ref: "http://schemas.taskcluster.net/queue/v1/task.json#"}
-        credentials:  {$const: task-credentials}
+        task:           {$ref: "http://schemas.taskcluster.net/queue/v1/task.json#"}
+        credentials:    {$ref: "http://schemas.taskcluster.net/queue/v1/task-credentials.json#"}
       additionalProperties: false
       required:
         - status

--- a/schemas/constants.yml
+++ b/schemas/constants.yml
@@ -69,48 +69,6 @@ created:
   type:         string
   format:       date-time
 
-# Task credentials issued with claim and reclaim, covering task.scopes
-task-credentials:
-  type:         object
-  additionalProperties: false
-  description: |
-    Temporary credentials granting `task.scopes` and the scope:
-    `queue:claim-task:<taskId>/<runId>` which allows the worker to reclaim
-    the task, upload artifacts and report task resolution.
-
-    The temporary credentials are set to expire after `takenUntil`. They
-    won't expire exactly at `takenUntil` but shortly after, hence, requests
-    coming close `takenUntil` won't have problems even if there is a little
-    clock drift.
-
-    Workers should use these credentials when making requests on behalf of
-    a task. This includes requests to create artifacts, reclaiming the task
-    reporting the task `completed`, `failed` or `exception`.
-
-    Note, a new set of temporary credentials is issued when the worker
-    reclaims the task.
-  properties:
-    clientId:
-      type:       string
-      minLength:  1
-      description: |
-        The `clientId` for the temporary credentials.
-    accessToken:
-      type:       string
-      minLength:  1
-      description: |
-        The `accessToken` for the temporary credentials.
-    certificate:
-      type:       string
-      minLength:  1
-      description: |
-        The `certificate` for the temporary credentials, these are required
-        for the temporary credentials to work.
-  required:
-  - clientId
-  - accessToken
-  - certificate
-
 # Message version numbers
 message-version:
   description:  Message version

--- a/schemas/create-task-request.yml
+++ b/schemas/create-task-request.yml
@@ -159,57 +159,14 @@ properties:
       `docker-worker` requires keys like: `image`, `commands` and
       `features`. Refer to the documentation of `docker-worker` for details.
     type:           object
-  metadata:
-    title:          "Meta-data"
-    description: |
-      Required task metadata
-    type:           object
-    properties:
-      name:
-        title:          "Name"
-        description: |
-          Human readable name of task, used to very briefly given an idea about
-          what the task does.
-        type:           string
-        maxLength:      255
-      description:
-        title:          "Description"
-        description: |
-          Human readable description of the task, please **explain** what the
-          task does. A few lines of documentation is not going to hurt you.
-        type:           string
-        maxLength:      32768
-      owner:
-        title:          "Owner"
-        description: |
-          E-mail of person who caused this task, e.g. the person who did
-          `hg push`. The person we should contact to ask why this task is here.
-        type:           string
-        format:         email
-        maxLength:      255
-      source:
-        title:          "Source"
-        description: |
-          Link to source of this task, should specify a file, revision and
-          repository. This should be place someone can go an do a git/hg blame
-          to who came up with recipe for this task.
-        type:           string
-        format:         uri
-        pattern:        {$const: source-pattern}
-        maxLength:      4096
-    additionalProperties: false
-    required:
-      - name
-      - description
-      - owner
-      - source
+  metadata:         {$ref: "http://schemas.taskcluster.net/queue/v1/task-metadata.json#"}
   tags:
     title:            "Tags"
     description: |
       Arbitrary key-value tags (only strings limited to 4k). These can be used
-      to attach informal meta-data to a task. Use this for informal tags that
+      to attach informal metadata to a task. Use this for informal tags that
       tasks can be classified by. You can also think of strings here as
-      candidates for formal meta-data. Something like
+      candidates for formal metadata. Something like
       `purpose: 'build' || 'test'` is a good example.
     type:             object
     additionalProperties:

--- a/schemas/list-workers-response.yml
+++ b/schemas/list-workers-response.yml
@@ -10,6 +10,7 @@ properties:
     description: |
       List of workers in this worker-type.
     items:
+      title:        "Worker"
       type:         object
       properties:
         workerGroup:
@@ -45,27 +46,7 @@ properties:
           title:          "Most Recent Task"
           description: |
             The most recent claimed task
-          type:       object
-          properties:
-            taskId:
-              title:            "Task Identifier"
-              description: |
-                Unique task identifier, this is UUID encoded as
-                [URL-safe base64](http://tools.ietf.org/html/rfc4648#section-5) and
-                stripped of `=` padding.
-              type:             string
-              pattern:          {$const: slugid-pattern}
-            runId:
-              title:            "Run Identifier"
-              description: |
-                Id of this task run, `run-id`s always starts from `0`
-              type:             integer
-              minimum:          {$const: min-run-id}
-              maximum:          {$const: max-run-id}
-          required:
-            - taskId
-            - runId
-          additionalProperties: false
+          $ref:       "http://schemas.taskcluster.net/queue/v1/task-run.json#"
       additionalProperties: false
       required:
         - workerGroup

--- a/schemas/list-workertypes-response.yml
+++ b/schemas/list-workertypes-response.yml
@@ -11,6 +11,7 @@ properties:
       List of worker-types in this provisioner.
     items:
       type:         object
+      title:        "Worker Type"
       properties:
         workerType:
           type:           string

--- a/schemas/pending-tasks-response.yml
+++ b/schemas/pending-tasks-response.yml
@@ -27,7 +27,7 @@ properties:
     title:          "Number of Pending Tasks"
     description: |
       An approximate number of pending tasks for the given `provisionerId` and
-      `workerType`. This is based on Azure Queue Storage meta-data API, thus,
+      `workerType`. This is based on Azure Queue Storage metadata API, thus,
       number of reported here may be higher than actual number of pending tasks.
       But there cannot be more pending tasks reported here. Ie. this is an
       **upper-bound** on the number of pending tasks.

--- a/schemas/post-artifact-request.yml
+++ b/schemas/post-artifact-request.yml
@@ -86,6 +86,7 @@ oneOf:
         type: array
         minLength: 1
         items:
+          title: "Multipart Part"
           type: object
           additionalProperties: false
           properties:

--- a/schemas/post-artifact-response.yml
+++ b/schemas/post-artifact-response.yml
@@ -25,6 +25,7 @@ oneOf:
           artifact.
         type: array
         items:
+          title: "HTTP Request"
           type: object
           properties:
             url:
@@ -47,6 +48,11 @@ oneOf:
               additionalProperties:
                 type:
                   string
+          additionalProperties: false
+          required:
+            - url
+            - method
+            - headers
     additionalProperties: false
     required:
       - requests

--- a/schemas/task-claim-response.yml
+++ b/schemas/task-claim-response.yml
@@ -31,8 +31,8 @@ properties:
       with reason `claim-expired` if the run haven't been reclaimed.
     type:         string
     format:       date-time
-  task: {$ref: "http://schemas.taskcluster.net/queue/v1/task.json#"}
-  credentials:  {$const: task-credentials}
+  task:           {$ref: "http://schemas.taskcluster.net/queue/v1/task.json#"}
+  credentials:    {$ref: "http://schemas.taskcluster.net/queue/v1/task-credentials.json#"}
 additionalProperties: false
 required:
   - status

--- a/schemas/task-credentials.yml
+++ b/schemas/task-credentials.yml
@@ -1,0 +1,41 @@
+$schema:          http://json-schema.org/draft-06/schema#
+title:            "Task Credentials"
+type:         object
+additionalProperties: false
+description: |
+  Temporary credentials granting `task.scopes` and the scope:
+  `queue:claim-task:<taskId>/<runId>` which allows the worker to reclaim
+  the task, upload artifacts and report task resolution.
+
+  The temporary credentials are set to expire after `takenUntil`. They
+  won't expire exactly at `takenUntil` but shortly after, hence, requests
+  coming close `takenUntil` won't have problems even if there is a little
+  clock drift.
+
+  Workers should use these credentials when making requests on behalf of
+  a task. This includes requests to create artifacts, reclaiming the task
+  reporting the task `completed`, `failed` or `exception`.
+
+  Note, a new set of temporary credentials is issued when the worker
+  reclaims the task.
+properties:
+  clientId:
+    type:       string
+    minLength:  1
+    description: |
+      The `clientId` for the temporary credentials.
+  accessToken:
+    type:       string
+    minLength:  1
+    description: |
+      The `accessToken` for the temporary credentials.
+  certificate:
+    type:       string
+    minLength:  1
+    description: |
+      The `certificate` for the temporary credentials, these are required
+      for the temporary credentials to work.
+required:
+- clientId
+- accessToken
+- certificate

--- a/schemas/task-metadata.yml
+++ b/schemas/task-metadata.yml
@@ -1,0 +1,44 @@
+$schema:            http://json-schema.org/draft-06/schema#
+title:              "Task Metadata"
+description: |
+  Required task metadata
+type:               object
+properties:
+  name:
+    title:          "Name"
+    description: |
+      Human readable name of task, used to very briefly given an idea about
+      what the task does.
+    type:           string
+    maxLength:      255
+  description:
+    title:          "Description"
+    description: |
+      Human readable description of the task, please **explain** what the
+      task does. A few lines of documentation is not going to hurt you.
+    type:           string
+    maxLength:      32768
+  owner:
+    title:          "Owner"
+    description: |
+      E-mail of person who caused this task, e.g. the person who did
+      `hg push`. The person we should contact to ask why this task is here.
+    type:           string
+    format:         email
+    maxLength:      255
+  source:
+    title:          "Source"
+    description: |
+      Link to source of this task, should specify a file, revision and
+      repository. This should be place someone can go an do a git/hg blame
+      to who came up with recipe for this task.
+    type:           string
+    format:         uri
+    pattern:        {$const: source-pattern}
+    maxLength:      4096
+additionalProperties: false
+required:
+  - name
+  - description
+  - owner
+  - source

--- a/schemas/task-reclaim-response.yml
+++ b/schemas/task-reclaim-response.yml
@@ -31,7 +31,7 @@ properties:
       with reason `claim-expired` if the run haven't been reclaimed.
     type:         string
     format:       date-time
-  credentials:  {$const: task-credentials}
+  credentials:    {$ref: "http://schemas.taskcluster.net/queue/v1/task-credentials.json#"}
 additionalProperties: false
 required:
   - status

--- a/schemas/task-run.yml
+++ b/schemas/task-run.yml
@@ -1,0 +1,25 @@
+$schema:              http://json-schema.org/draft-06/schema#
+title:                "Task Run"
+description: |
+  A run of a task.
+type:                 object
+additionalProperties: false
+properties:
+  taskId:
+    title:            "Task Identifier"
+    description: |
+      Unique task identifier, this is UUID encoded as
+      [URL-safe base64](http://tools.ietf.org/html/rfc4648#section-5) and
+      stripped of `=` padding.
+    type:             string
+    pattern:          {$const: slugid-pattern}
+  runId:
+    title:            "Run Identifier"
+    description: |
+      Id of this task run, `run-id`s always starts from `0`
+    type:             integer
+    minimum:          {$const: min-run-id}
+    maximum:          {$const: max-run-id}
+required:
+  - taskId
+  - runId

--- a/schemas/task.yml
+++ b/schemas/task.yml
@@ -144,57 +144,14 @@ properties:
       `docker-worker` requires keys like: `image`, `commands` and
       `features`. Refer to the documentation of `docker-worker` for details.
     type:           object
-  metadata:
-    title:          "Meta-data"
-    description: |
-      Required task metadata
-    type:           object
-    properties:
-      name:
-        title:          "Name"
-        description: |
-          Human readable name of task, used to very briefly given an idea about
-          what the task does.
-        type:           string
-        maxLength:      255
-      description:
-        title:          "Description"
-        description: |
-          Human readable description of the task, please **explain** what the
-          task does. A few lines of documentation is not going to hurt you.
-        type:           string
-        maxLength:      32768
-      owner:
-        title:          "Owner"
-        description: |
-          E-mail of person who caused this task, e.g. the person who did
-          `hg push`. The person we should contact to ask why this task is here.
-        type:           string
-        format:         email
-        maxLength:      255
-      source:
-        title:          "Source"
-        description: |
-          Link to source of this task, should specify a file, revision and
-          repository. This should be place someone can go an do a git/hg blame
-          to who came up with recipe for this task.
-        type:           string
-        format:         uri
-        pattern:        {$const: source-pattern}
-        maxLength:      4096
-    additionalProperties: false
-    required:
-      - name
-      - description
-      - owner
-      - source
+  metadata:         {$ref: "http://schemas.taskcluster.net/queue/v1/task-metadata.json#"}
   tags:
     title:            "Tags"
     description: |
       Arbitrary key-value tags (only strings limited to 4k). These can be used
-      to attach informal meta-data to a task. Use this for informal tags that
+      to attach informal metadata to a task. Use this for informal tags that
       tasks can be classified by. You can also think of strings here as
-      candidates for formal meta-data. Something like
+      candidates for formal metadata. Something like
       `purpose: 'build' || 'test'` is a good example.
     type:             object
     additionalProperties:

--- a/schemas/worker-response.yml
+++ b/schemas/worker-response.yml
@@ -37,29 +37,12 @@ properties:
     maxLength:    {$const: identifier-max-length}
     pattern:      {$const: identifier-pattern}
   recentTasks:
-    title:        "Recent Tasks"
+    title:        "Most Recent Tasks"
     description: |
       List of 20 most recent tasks claimed by the worker.
     type:         array
     items:
-      type:       object
-      additionalProperties: false
-      properties:
-        taskId:
-          title:            "Task Identifier"
-          description: |
-            Unique task identifier, this is UUID encoded as
-            [URL-safe base64](http://tools.ietf.org/html/rfc4648#section-5) and
-            stripped of `=` padding.
-          type:             string
-          pattern:          {$const: slugid-pattern}
-        runId:
-          title:            "Run Identifier"
-          description: |
-            Id of this task run, `run-id`s always starts from `0`
-          type:             integer
-          minimum:          {$const: min-run-id}
-          maximum:          {$const: max-run-id}
+      $ref:       "http://schemas.taskcluster.net/queue/v1/task-run.json#"
   expires:
     title:        "Worker Expiration"
     description: |


### PR DESCRIPTION
This should be everything now. In total it reduces the schemas line count by 45 lines by removing duplication, which also removes the duplicated go types.

* I put common data structures into new files (`task-run.yml`, `task-credentials.yml`, `task-metadata.yml`) and `$ref` them
* Spelling correction: meta-data -> metadata
* Added missing titles that improve generated go code
* I made (`url`, `method`, `headers`) required properties, and disallowed additional properties, in Blob Artifact Response HTTP requests
* All tests pass 🕺 