### PR TITLE
Adjust schema titles for consistency

### DIFF
--- a/schemas/artifact-created-message.yml
+++ b/schemas/artifact-created-message.yml
@@ -29,7 +29,7 @@ properties:
     maxLength:    {$const: "identifier-max-length"}
     pattern:      {$const: "identifier-pattern"}
   artifact:
-    title:        "Artifact Created"
+    title:        "Artifact"
     description: |
       Information about the artifact that was created
     type:         object

--- a/schemas/task-group-resolved.yml
+++ b/schemas/task-group-resolved.yml
@@ -1,5 +1,5 @@
 $schema:            http://json-schema.org/draft-06/schema#
-title:              "Task Group Resolved"
+title:              "Task Group Resolved Message"
 description: |
   Message written once a task group has no tasks to be run. It is
   possible for a task group to later have another task added, in which


### PR DESCRIPTION
This has the pleasant side effect of improving `tcqueueevents` generated types.

See [generated types](https://godoc.org/github.com/taskcluster/taskcluster-client-go/tcqueueevents) for context.

```
TaskGroupResolved1 -> TaskGroupResolvedMessage
ArtifactCreated1 -> Artifact
```