### PR TITLE
Bug 1478835 - fix support for useCloudMirror

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -93,12 +93,12 @@ defaults:
     # Mapping from EC2 region to public artifact bucket proxy
     # (Must not end with a slash!)
     publicArtifactBucketProxies:  !env:json PUBLIC_ARTIFACT_EC2_PROXIES
-    usePublicArtifactBucketProxy: true
 
     # CDN for public artifact bucket
     publicArtifactBucketCDN:      !env PUBLIC_ARTIFACT_BUCKET_CDN
 
     # Cloud mirror configuration
+    useCloudMirror:               !env:bool USE_CLOUD_MIRROR
     cloudMirrorHost:              'cloud-mirror.taskcluster.net'
 
 
@@ -162,7 +162,6 @@ production:
       - us-east-2
       - us-west-1
       - eu-central-1
-    useCloudMirror: !env:bool USE_PUBLIC_ARTIFACT_BUCKET_PROXY
   server:
     env:              production
     trustProxy:       true

--- a/src/api.js
+++ b/src/api.js
@@ -117,6 +117,7 @@ var builder = new APIBuilder({
     'workerInfo',         // Instance of WorkerInfo
     's3Controller',       // Instance of remotely-signed-s3.Controller
     's3Runner',           // Instance of remotely-signed-s3.Runner
+    'useCloudMirror',     // If true, use the cloud-mirror service
     'cloudMirrorHost',    // Hostname of the cloud-mirror service
     'artifactRegion',     // Region where artifacts are stored (no cloud-mirror)
     'blobRegion',         // Region where blobs are stored (no cloud-mirror)

--- a/src/artifacts.js
+++ b/src/artifacts.js
@@ -567,6 +567,10 @@ var replyWithArtifact = async function(taskId, runId, name, req, res) {
         skipCache = true;
       }
 
+      if (!this.useCloudMirror) {
+        skipCache = true;
+      }
+
       if (skipCache && skipCDN) {
         url = this.publicBucket.createGetUrl(prefix, true);
       } else if (skipCache || !region) {

--- a/src/main.js
+++ b/src/main.js
@@ -413,8 +413,9 @@ let load = loader({
     requires: ['cfg'],
     setup: async ({cfg}) => {
       let regionResolver = new EC2RegionResolver(
-        cfg.app.useCloudMirror ? [...cfg.app.cloudMirrorRegions, cfg.aws.region] : []
-      );
+        cfg.app.useCloudMirror ?
+          [...cfg.app.cloudMirrorRegions, cfg.aws.region] :
+          [cfg.aws.region]);
       await regionResolver.loadIpRanges();
       return regionResolver;
     },
@@ -468,6 +469,7 @@ let load = loader({
         privateBucket:    ctx.privateArtifactBucket,
         regionResolver:   ctx.regionResolver,
         credentials:      ctx.cfg.taskcluster.credentials,
+        useCloudMirror:   !!ctx.cfg.app.useCloudMirror,
         cloudMirrorHost:  ctx.cfg.app.cloudMirrorHost,
         artifactRegion:   ctx.cfg.aws.region,
         monitor:          ctx.monitor.prefix('api-context'),


### PR DESCRIPTION
This includes renaming the env var to USE_CLOUD_MIRROR for consistency
with the JS name and removing the unused `usePublicArtifactBucketProxy`
configuration property.

Thanks to @jhford for most of this patch :)

---

I already added USE_CLOUD_MIRROR to the heroku config.