### PR TITLE
Bug 1508849 - implement **-scope protection differently

### DIFF
--- a/schemas/constants.yml
+++ b/schemas/constants.yml
@@ -94,7 +94,7 @@ scope:
       A single scope. A scope must be composed of
       printable ASCII characters and spaces.  Scopes ending in more than
       one `*` character are forbidden.
-    pattern: "^[\x20-\x7e]*(?<!\\*\\*)$"
+    pattern: "^[\x20-\x7e]*$"
 
 # Pattern for source URLs; this rules out insecure URLs like data: or javascript:
 source-pattern: "^https?://"

--- a/src/api.js
+++ b/src/api.js
@@ -620,6 +620,10 @@ builder.declare({
     workerType: taskDef.workerType,
   });
 
+  if (taskDef.scopes.some(s => s.endsWith('**'))) {
+    return res.reportError('InputError', 'scopes must not end with `**`', {});
+  }
+
   // Ensure group membership is declared, and that schedulerId isn't conflicting
   if (!await ensureTaskGroup(this, taskId, taskDef, res)) {
     return;

--- a/test/createtask_test.js
+++ b/test/createtask_test.js
@@ -99,7 +99,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
       .then(
         () => { throw new Error('Expected an authentication error'); },
         (err) => {
-          if (err.code != 'InputValidationError') {
+          if (err.code != 'InputError') {
             throw err;
           }
         });


### PR DESCRIPTION
The old solution used a negative lookbehind, which per
https://json-schema.org/understanding-json-schema/reference/regular_expressions.html#regular-expressions
is not supported in json-schema. In fact, it's not supported in even
fairly recent versions of Node. This causes problems when validating
schemas using those old versions of node (or using json-schema
validators that do not support this form).

So, the new solution is to explicitly forbid those forms where used in
creating clients and roles. The result is much the same, as evidenced
by the minimal changes to the tests.