### PR TITLE
Bug 1502892 - refactor create/defineTask to check authorization before validation

### DIFF
--- a/test/createtask_test.js
+++ b/test/createtask_test.js
@@ -316,12 +316,35 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     });
   });
 
-  // Test for compatibility only
-  test('Can create "normal" without queue:task-priority:high', async () => {
+  test('Can create "normal" priority task with ..:lowest:.. scope', async () => {
+    helper.scopes(
+      'queue:create-task:lowest:no-provisioner/test-worker',
+      'queue:scheduler-id:test-run',
+    );
+    await helper.queue.createTask(slugid.v4(), makePriorityTask('normal'));
+  });
+
+  test('Can create "normal" priority task with legacy scope', async () => {
     helper.scopes(
       'queue:create-task:no-provisioner/test-worker',
     );
     await helper.queue.createTask(slugid.v4(), makePriorityTask('normal'));
   });
 
+  test('Can create "lowest" priority task with ..:lowest:.. scope', async () => {
+    helper.scopes(
+      'queue:create-task:lowest:no-provisioner/test-worker',
+      'queue:scheduler-id:test-run',
+    );
+    await helper.queue.createTask(slugid.v4(), makePriorityTask('lowest'));
+  });
+
+  test('Can create "lowest" priority task with legacy scope', async () => {
+    // This is perhaps not intended, but since lowest is treated the same
+    // as normal, the legacy scope works for lowest, too.
+    helper.scopes(
+      'queue:create-task:no-provisioner/test-worker',
+    );
+    await helper.queue.createTask(slugid.v4(), makePriorityTask('lowest'));
+  });
 });


### PR DESCRIPTION
This keeps with the maxim that you should check for permission as early as possible, before trusting any other data.  The user-visible change is that a task that is both invalid and not authorized will now result in an authorization error rather than an InputError.

Another approach may be to break `patchAndValidateTaskDef` into `patchTaskDef` and `validateTaskDef`.